### PR TITLE
add editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# ensure the LF line endings
+[*.abap]
+charset = utf-8
+end_of_line = lf
+
+# ensure the LF line endings
+[*.properties]
+charset = utf-8
+end_of_line = lf
+
+
+# we want indentation of 4 spaces
+[*.json]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Many text editors (vs code, eclipse, ...) does support this type of style definition, through plug-ins or naitively, see https://editorconfig.org/#download

Having a common style definition on our local editors facilitates code sharing