### PR TITLE
Update JSON-schema version to 2020-12

### DIFF
--- a/file-formats/enho/enho.json
+++ b/file-formats/enho/enho.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-09/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "http://github.com/SAP/abap-file-formats/file-formats/enho/enho.json",
     "type": "object",
     "properties": {

--- a/file-formats/enhs/enhs.json
+++ b/file-formats/enhs/enhs.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-09/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "http://github.com/SAP/abap-file-formats/file-formats/enhs/enhs.json",
     "type": "object",
     "properties": {

--- a/file-formats/fugr/fugr.json
+++ b/file-formats/fugr/fugr.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-09/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "http://github.com/SAP/abap-file-formats/file-formats/fugr/fugr.json",
     "type": "object",
     "properties": {

--- a/file-formats/fugr/func.json
+++ b/file-formats/fugr/func.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-09/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "http://github.com/SAP/abap-file-formats/file-formats/fugr/func.json",
     "type": "object",
     "properties": {

--- a/file-formats/fugr/reps.json
+++ b/file-formats/fugr/reps.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft/2019-09/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "http://github.com/SAP/abap-file-formats/file-formats/fugr/reps.json",
     "type": "object",
     "properties": {


### PR DESCRIPTION
Not all JSON schema files referred to the latest JSON schema version `https://json-schema.org/draft/2020-12/schema`

See #39.