### PR TITLE
Be precise with metadata

### DIFF
--- a/file-formats/chko/format.md
+++ b/file-formats/chko/format.md
@@ -6,4 +6,4 @@ The JSON schema is provided [here](./chko.json).
 
 File | Content
  --- | ---
-[`z_aff_example_chko.chko.json`](./examples/z_aff_example_chko.chko.json) | Metadata of ATC Check Object
+[`z_aff_example_chko.chko.json`](./examples/z_aff_example_chko.chko.json) | File representation of an ATC Check Object

--- a/file-formats/clas/format.md
+++ b/file-formats/clas/format.md
@@ -7,7 +7,7 @@ The JSON schema for the class metadata file is provided [here](./clas.json).
 Example files for a class `zcl_aff_example` are provided in the following table.
 File | Content
  --- | ---
-[`zcl_aff_example.clas.json`](./examples/zcl_aff_example.clas.json)                                 | Metadata of the ABAP class
+[`zcl_aff_example.clas.json`](./examples/zcl_aff_example.clas.json)                                 | Properties and descriptions of the ABAP class
 [`zcl_aff_example.clas.definitions.abap`](./examples/zcl_aff_example.clas.definitions.abap)         | Class-relevant Local Types
 [`zcl_aff_example.clas.global.abap`](./examples/zcl_aff_example.clas.global.abap)                   | Global Class
 [`zcl_aff_example.clas.implementations.abap`](./examples/zcl_aff_example.clas.implementations.abap) | Local Types

--- a/file-formats/fugr/format.md
+++ b/file-formats/fugr/format.md
@@ -1,21 +1,21 @@
 # File Format for Object Type FUGR
 
 Files with ending `.abap` contain plain ABAP source code.
-A function group can contain two sub object types (reps and func) which need a metadata file themselves.
-The JSON schema for the function group metadata file is provided [here](./fugr.json).
-The JSON schema for the function group include (reps) metadata file is provided [here](./reps.json).
-The JSON schema for the function module (func) metadata file is provided [here](./func.json).
+A function group can contain two sub object types (reps and func) which need a properties file themselves.
+The JSON schema for the function group property file is provided [here](./fugr.json).
+The JSON schema for the function group include (reps) property file is provided [here](./reps.json).
+The JSON schema for the function module (func) property file is provided [here](./func.json).
 
 Example files for a function group `z_aff_example_fugr` are provided in the following table.
 File | Content
  --- | ---
-[`z_aff_example_fugr.fugr.json`](./examples/z_aff_example_fugr.fugr.json)                 | Metadata of the FUGR
+[`z_aff_example_fugr.fugr.json`](./examples/z_aff_example_fugr.fugr.json)                 | Properties and descriptions of the FUGR
 [`saplz_aff_example_fugr.reps.abap`](./examples/saplz_aff_example_fugr.reps.abap)         | Source Code of the SAPL Include
-[`saplz_aff_example_fugr.reps.json`](./examples/saplz_aff_example_fugr.reps.json)         | Metadata of the SAPL Include
+[`saplz_aff_example_fugr.reps.json`](./examples/saplz_aff_example_fugr.reps.json)         | Properties and descriptions of the SAPL Include
 [`lz_aff_example_fugrtop.reps.abap`](./examples/lz_aff_example_fugrtop.reps.abap) 	  | Source Code of the TOP Include
-[`lz_aff_example_fugrtop.reps.json`](./examples/lz_aff_example_fugrtop.reps.json)         | Metadata of the TOP Include
+[`lz_aff_example_fugrtop.reps.json`](./examples/lz_aff_example_fugrtop.reps.json)         | Properties and descriptions of the TOP Include
 [`z_aff_example_func.func.abap`](./examples/z_aff_example_func.func.abap)                 | Source Code of the included FUNC
-[`z_aff_example_func.func.json`](./examples/z_aff_example_func.func.json)                 | Metadata of the included FUNC
+[`z_aff_example_func.func.json`](./examples/z_aff_example_func.func.json)                 | Properties and descriptionss of the included FUNC
 [`z_aff_example_fugr.fugr.texts.en.properties`](./examples/z_aff_example_fugr.fugr.texts.en.properties)   | Translation relevant texts
 
 The following sub objects of FUGR are not yet supported:

--- a/file-formats/intf/format.md
+++ b/file-formats/intf/format.md
@@ -6,5 +6,5 @@ The JSON schema for the interface metadata file is provided [here](./intf.json).
 Example files for an interface `zif_aff_example` are provided in the following table.
 File | Content
  --- | ---
-[`zif_aff_example.intf.json`](./examples/zif_aff_example.intf.json)         | Metadata and descriptions of the ABAP interface
+[`zif_aff_example.intf.json`](./examples/zif_aff_example.intf.json)         | Properties and descriptions of the ABAP interface
 [`zif_aff_example.intf.abap`](./examples/zif_aff_example.intf.abap)         | Interface source code

--- a/file-formats/nrob/format.md
+++ b/file-formats/nrob/format.md
@@ -6,4 +6,4 @@ The JSON schema is provided [here](./nrob.json).
 
 File | Content
  --- | ---
-[`z_aff_nr.nrob.json`](./examples/z_aff_nr.nrob.json) | Metadata of number range object
+[`z_aff_nr.nrob.json`](./examples/z_aff_nr.nrob.json) | File representation of a number range object


### PR DESCRIPTION
Naming follows:
* ABAP objects with single file representation `File representation of the ABAP object`
* ABAP objects with multiple file represenation `Properties and descriptions of the ABAP object`

closes #31