### PR TITLE
refactor INTF

### DIFF
--- a/file-formats/intf/zif_aff_intf_v1.intf.abap
+++ b/file-formats/intf/zif_aff_intf_v1.intf.abap
@@ -40,8 +40,9 @@ INTERFACE zif_aff_intf_v1 PUBLIC.
     "! Event descriptions
     events TYPE SORTED TABLE OF event WITH UNIQUE KEY name.
 
-  "! Interface properties
-  TYPES: BEGIN OF main,
+  TYPES:
+    "! Interface properties
+    BEGIN OF main,
       header TYPE zif_aff_types_v1=>head-header,
       "! Type descriptions
       types      TYPE component_descriptions,

--- a/file-formats/intf/zif_aff_intf_v1.intf.abap
+++ b/file-formats/intf/zif_aff_intf_v1.intf.abap
@@ -11,32 +11,36 @@ INTERFACE zif_aff_intf_v1 PUBLIC.
     "! Interface component descriptions
     component_descriptions    TYPE SORTED TABLE OF component_description WITH UNIQUE KEY name,
     "! Sub component descriptions (e.g., for parameters or exceptions)
-    subcomponent_descriptions TYPE SORTED TABLE OF component_description WITH UNIQUE KEY name,
+    subcomponent_descriptions TYPE SORTED TABLE OF component_description WITH UNIQUE KEY name.
 
-    "! Method description
-    BEGIN OF method.
-      INCLUDE TYPE component_description.
-  TYPES:
+  "! Method description
+  TYPES: BEGIN OF method,
+      name        TYPE zif_aff_types_v1=>object_name_30,
+      "! Description of the component
+      description TYPE zif_aff_types_v1=>description_60,
       "! Parameter descriptions
       parameters TYPE subcomponent_descriptions,
       "! Exception descriptions
       exceptions TYPE subcomponent_descriptions,
     END OF method,
     "! Method descriptions
-    methods TYPE SORTED TABLE OF method WITH UNIQUE KEY name,
+    methods TYPE SORTED TABLE OF method WITH UNIQUE KEY name.
 
-    "! Event description
-    BEGIN OF event.
-      INCLUDE TYPE component_description.
-  TYPES:
+  "! Event description
+  TYPES: BEGIN OF event,
+      "! Name of the component
+      name        TYPE zif_aff_types_v1=>object_name_30,
+      "! Description of the component
+      description TYPE zif_aff_types_v1=>description_60,
       "! Parameter descriptions
       parameters TYPE subcomponent_descriptions,
     END OF event,
     "! Event descriptions
-    events TYPE SORTED TABLE OF event WITH UNIQUE KEY name,
+    events TYPE SORTED TABLE OF event WITH UNIQUE KEY name.
 
-    "! Interface properties content
-    BEGIN OF content,
+  "! Interface properties
+  TYPES: BEGIN OF main,
+      header TYPE zif_aff_types_v1=>head-header,
       "! Type descriptions
       types      TYPE component_descriptions,
       "! Attribute descriptions
@@ -45,13 +49,6 @@ INTERFACE zif_aff_intf_v1 PUBLIC.
       events     TYPE events,
       "! Method descriptions
       methods    TYPE methods,
-    END OF content,
-
-    "! Interface properties
-    BEGIN OF main.
-      INCLUDE TYPE zif_aff_types_v1=>head.
-      INCLUDE TYPE content.
-  TYPES:
     END OF main.
 
 ENDINTERFACE.

--- a/file-formats/intf/zif_aff_intf_v1.intf.abap
+++ b/file-formats/intf/zif_aff_intf_v1.intf.abap
@@ -13,8 +13,9 @@ INTERFACE zif_aff_intf_v1 PUBLIC.
     "! Sub component descriptions (e.g., for parameters or exceptions)
     subcomponent_descriptions TYPE SORTED TABLE OF component_description WITH UNIQUE KEY name.
 
-  "! Method description
-  TYPES: BEGIN OF method,
+  TYPES:
+    "! Method description
+    BEGIN OF method,
       name        TYPE zif_aff_types_v1=>object_name_30,
       "! Description of the component
       description TYPE zif_aff_types_v1=>description_60,

--- a/file-formats/intf/zif_aff_intf_v1.intf.abap
+++ b/file-formats/intf/zif_aff_intf_v1.intf.abap
@@ -26,8 +26,9 @@ INTERFACE zif_aff_intf_v1 PUBLIC.
     "! Method descriptions
     methods TYPE SORTED TABLE OF method WITH UNIQUE KEY name.
 
-  "! Event description
-  TYPES: BEGIN OF event,
+  TYPES: 
+    "! Event description
+    BEGIN OF event,
       "! Name of the component
       name        TYPE zif_aff_types_v1=>object_name_30,
       "! Description of the component

--- a/file-formats/intf/zif_aff_intf_v1.intf.abap
+++ b/file-formats/intf/zif_aff_intf_v1.intf.abap
@@ -27,7 +27,7 @@ INTERFACE zif_aff_intf_v1 PUBLIC.
     "! Method descriptions
     methods TYPE SORTED TABLE OF method WITH UNIQUE KEY name.
 
-  TYPES: 
+  TYPES:
     "! Event description
     BEGIN OF event,
       "! Name of the component

--- a/file-formats/intf/zif_aff_types_v1.intf.abap
+++ b/file-formats/intf/zif_aff_types_v1.intf.abap
@@ -1,8 +1,7 @@
 INTERFACE zif_aff_types_v1 PUBLIC.
 
-  TYPES:
-    "! Language
-    language TYPE c LENGTH 2.
+  "! Language
+  TYPES language TYPE c LENGTH 2.
 
   TYPES:
     "! ABAP language version
@@ -29,12 +28,10 @@ INTERFACE zif_aff_types_v1 PUBLIC.
       END OF header,
     END OF head.
 
-  TYPES:
-    "! Description with 60 characters
-    description_60    TYPE c LENGTH 60.
+  "! Description with 60 characters
+  TYPES description_60 TYPE c LENGTH 60.
 
-  TYPES:
-    "! Object name with max. length 30
-    object_name_30 TYPE c LENGTH 30.
+  "! Object name with max. length 30
+  TYPES object_name_30 TYPE c LENGTH 30.
 
 ENDINTERFACE.


### PR DESCRIPTION
With 16+ years in ABAP I'm a newbie, and I have trouble reading the source code, this refactors INTF and removes all INCLUDE STRUCTURE, hopefully making it easier for humans to read.

It does however, sacrifice some reuse and introduces a bit of duplication, but IMHO its okay

Note that the `schema` field is removed from the header! `$schema` is not a json schema property, its a thing implemented in some editors like vscode. Editors have mechanisms to identify the correct schema for a file, I don't think we want to persist a URL inside the files, it might change in the future.

single definitions refactored to abapdoc + ABAP, instead of ABAP + abapdoc + ABAP, to
```abap
  "! Language
  TYPES language TYPE c LENGTH 2.
```

from

```abap
  TYPES:
    "! Language
    language TYPE c LENGTH 2.
```

which also follows https://github.com/SAP/styleguides/blob/main/clean-abap/CleanABAP.md#do-not-chain-up-front-declarations