### PR TITLE
Change language version v751 to v702

### DIFF
--- a/abaplint.jsonc
+++ b/abaplint.jsonc
@@ -10,7 +10,7 @@
   },
   "dependencies": [],
   "syntax": {
-    "version": "v751",
+    "version": "v702",
     "errorNamespace": ".",
     "globalConstants": [],
     "globalMacros": []


### PR DESCRIPTION
If ENUMS are not required, we can change the language version to 702

can be merged after https://github.com/SAP/abap-file-formats/pull/95 is merged