### PR TITLE
be more precise with json schema

### DIFF
--- a/file-formats/chkv/chkv.json
+++ b/file-formats/chkv/chkv.json
@@ -165,58 +165,46 @@
                         "description": "The high value of the range",
                         "type": "string"
                       }
-                    }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "sign",
+                      "option",
+                      "low",
+                      "high"
+                    ]
                   }
                 }
-              }
-            }
-          }
-        }
-      }
-    },
-    "oneOf": [
-      {
-        "required": [
-          "valueList"
-        ]
-      },
-      {
-        "required": [
-          "valueRangeList"
-        ]
-      },
-      {
-        "required": [
-          "value"
-        ]
-      }
-    ],
-    "allOf": [
-      {
-        "if": {
-          "properties": {
-            "type": {
-              "const": "^rangeOf"
+              },
+              "oneOf": [
+                {
+                  "required": [
+                    "valueList"
+                  ]
+                },
+                {
+                  "required": [
+                    "valueRangeList"
+                  ]
+                },
+                {
+                  "required": [
+                    "value"
+                  ]
+                }
+              ],
+              "required": [
+                "name",
+                "type"
+              ]
             }
           }
         },
-        "then": {
-          "required": "valueRangeList"
-        }
-      },
-      {
-        "if": {
-          "properties": {
-            "type": {
-              "const": "^tableOf"
-            }
-          }
-        },
-        "then": {
-          "required": "valueList"
-        }
+        "required": [
+          "checkName"
+        ]
       }
-    ]
+    }
   },
   "additionalProperties": false,
   "required": [


### PR DESCRIPTION
  - enforce checkName
  - allow only one of {value, valueList, ValueRangeList}
  - check for complete sign, option, low and high in ValueRangeLists
  - parameters must contain name and type
  - dropped the logic for type and valueRangeList, valueList, ...