### PR TITLE
CLAS: Correct example

### DIFF
--- a/file-formats/clas/examples/zcl_aff_example.clas.json
+++ b/file-formats/clas/examples/zcl_aff_example.clas.json
@@ -5,7 +5,6 @@
     "originalLanguage": "EN",
     "abapLanguageVersion": "standard"
   },
-  "category": "generalObjectType",
   "fixPointArithmetic": true,
   "types": [
     {


### PR DESCRIPTION
The field `category` is not tagged with `$required` or `$showAlways`. Hence, category `generalObjectType` (ABAP Type 00) shall not be written in serialization process. 