### PR TITLE
rm type in chkv

### DIFF
--- a/file-formats/chkv/chkv.json
+++ b/file-formats/chkv/chkv.json
@@ -170,8 +170,7 @@
               },
               "additionalProperties": false,
               "required": [
-                "name",
-                "type"
+                "name"
               ]
             }
           }

--- a/file-formats/chkv/chkv.json
+++ b/file-formats/chkv/chkv.json
@@ -85,11 +85,6 @@
                   "type": "string",
                   "maxLength": 30
                 },
-                "type": {
-                  "title": "Parameter Type",
-                  "description": "The parameter type",
-                  "type": "string"
-                },
                 "value": {
                   "title": "Parameter Value",
                   "description": "The value of the parameter",

--- a/file-formats/chkv/examples/z_aff_example_chkv.chkv.json
+++ b/file-formats/chkv/examples/z_aff_example_chkv.chkv.json
@@ -11,7 +11,6 @@
       "parameters": [
         {
           "name": "StatementPattern",
-          "type": "tableOfSychar72",
           "valueList": [
             "CALL FUNCTION 'DB_EXISTS_INDEX' *",
             "CALL FUNCTION 'DD_INDEX_NAME' *"
@@ -19,7 +18,6 @@
         },
         {
           "name": "FindingSeverity",
-          "type": "sychar01",
           "value": "E"
         }
       ]
@@ -29,7 +27,6 @@
       "parameters": [
         {
           "name": "ABAPLanguageVersion",
-          "type": "enum_MSGF_CL_CI_TEST_EXTENDED_CHECK_VERS",
           "value": "4"
         }
       ]
@@ -39,12 +36,10 @@
       "parameters": [
         {
           "name": "ReleaseID",
-          "type": "sycm_release_id",
           "value": "S4HANA_READINESS_1809"
         },
         {
           "name": "SAPNotes",
-          "type": "rangeOfSycm_sap_note_number_db_ops",
           "valueRangeList": [
             {
               "sign": "exclude",
@@ -56,7 +51,6 @@
         },
         {
           "name": "SimplificationItemCategories",
-          "type": "rangeOfSycm_sitem_state",
           "valueRangeList": [
             {
               "sign": "exclude",

--- a/file-formats/chkv/type/zif_aff_chkv_v1.intf.abap
+++ b/file-formats/chkv/type/zif_aff_chkv_v1.intf.abap
@@ -88,10 +88,6 @@ INTERFACE zif_aff_chkv_v1
       "! The parameter name
       "! $required
       name             TYPE zif_aff_types_v1=>ty_object_name_30,
-      "! <p class="shorttext">Parameter Type</p>
-      "! The parameter type
-      "! $required
-      type             TYPE string,
       "! <p class="shorttext">Parameter Value</p>
       "! The value of the parameter
       value            TYPE string,


### PR DESCRIPTION
Remove a non-required parameter in the file format definition for ABAP type CHKV

TODO:

- [x] align with ABAP type