### PR TITLE
"ABAP in Eclipse" is not a SAP-official term

### DIFF
--- a/file-formats/clas/format.md
+++ b/file-formats/clas/format.md
@@ -1,6 +1,6 @@
 # File Format for Object Type CLAS
 
-The files correspond to the tabs in ABAP in Eclipse, enriched with metadata and translation relevant texts.
+The files correspond to the tabs in the ABAP Development Tools, enriched with metadata and translation relevant texts.
 Files with the ending `.abap` contain plain ABAP source code.
 The JSON schema for the class metadata file is provided [here](./clas.json).
 

--- a/file-formats/clas/format.md
+++ b/file-formats/clas/format.md
@@ -1,6 +1,6 @@
 # File Format for Object Type CLAS
 
-The files correspond to the tabs in the ABAP Development Tools, enriched with metadata and translation relevant texts.
+The files correspond to the tabs in ABAP Development Tools, enriched with metadata and translation relevant texts.
 Files with the ending `.abap` contain plain ABAP source code.
 The JSON schema for the class metadata file is provided [here](./clas.json).
 


### PR DESCRIPTION
The term "ABAP in Eclipse" is not an offical term. The official name
is "ABAP Development Tools".