### PR TITLE
Add decision-record

### DIFF
--- a/doc/001-json-version.md
+++ b/doc/001-json-version.md
@@ -1,0 +1,88 @@
+# JSON Versioning
+
+* Status: [accepted] <!-- optional -->
+* Deciders: [https://github.com/orgs/SAP/teams/abap-file-formats-team] <!-- optional -->
+* Date: [2021-09] <!-- optional -->
+
+Technical Story:
+* https://github.com/SAP/abap-file-formats/issues/53
+* https://github.com/SAP/abap-file-formats/issues/83
+
+## Context and Problem Statement
+
+File format definitions are subjected to changes.
+With this decision we address the versioning of JSON schema for ABAP file formats.
+
+It is specified how the JSON schemas indicate versions and how this is reflected in the JSON data.
+
+
+
+## Considered Options
+JSON data:
+1. Indicate JSON version by `$schema`
+1. Indicate JSON version by `$schema` and `version`
+1. Indicate JSON version by `version`
+
+JSON schema:
+* Declare field `version` as enum located on root level
+1. Name `ABCD-v1.json` or `ABCD-v.1.json` for the first version of the JSON schema for ABAP object type `ABCD`
+2. Store all versions in `ABCD.json` and resolve the version inside by JSON schema logic
+
+
+## Decision Outcome
+
+In the context of ABAP, `version` ambiguous as it suggests 'in-/active' versions.
+Instead we agreed on `formatVersion`.
+Together with the JSON schema annotation, this is considered to be precise.
+
+We agreed on option 3 (JSON data) and option 1 (JSON schema).
+The JSON version is declared as enum on root level.
+
+
+### Positive Consequences <!-- optional -->
+
+* JSON data does not invalidate with URI changes in `$schema`, provoked by any change of folders or filenames
+* JSON data still decodes its version by `formatVersion`
+* Ever version of a JSON schema corresponds to a single file
+* Name `ABCD.json` is still possible, for example for a generated JSON schema that encodes all versions
+* The type `enum` suits the purpose of validation (preferred over string)
+
+### Negative Consequences <!-- optional -->
+
+* Build in validation and annotation, of JSON data, in editors like eclipse or vs Code is based on `$schema` and is not accessible out-of-the box
+* The logic of assigning JSON data to its JSON schema has to be provided by a third party, since it is no longer possible to resolve the URI in the JSON data
+
+
+## Other Options
+In the discussions we discarded the following options.
+
+### [option 1]
+
+Versioning by file name
+— | Instance | Schema
+:--- | :--- | :---
+File name | xy.chko-v.1.json | chko-v.1.json
+
+* Bad, because moving to the next version does rename the JSON data file
+* Bad, as the JSON data itself should know about the version
+
+### [option 2]
+
+As decides, but without field `formatVersion` or `version`.
+
+* Bad, the version information should be easily retrievable, not by decoding URIs
+
+
+### [option 3]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+## Links <!-- optional -->
+
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* … <!-- numbers of links can vary -->

--- a/doc/decision-log/0001-json-version.md
+++ b/doc/decision-log/0001-json-version.md
@@ -24,7 +24,7 @@ JSON data:
 1. Indicate JSON version by `version`
 
 JSON schema:
-* Declare field `version` as enum located on root level
+* Declare field `version` as `const` located on root level
 1. Name `ABCD-v1.json` or `ABCD-v.1.json` for the first version of the JSON schema for ABAP object type `ABCD`
 2. Store all versions in `ABCD.json` and resolve the version inside by JSON schema logic
 
@@ -36,32 +36,34 @@ Instead we agreed on `formatVersion`.
 Together with the JSON schema annotation, this is considered to be precise.
 
 We agreed on option 3 (JSON data) and option 1 (JSON schema).
-The JSON version is declared as enum on root level.
+The JSON version is declared as const on root level.
 
 
-### Positive Consequences <!-- optional -->
+### Positive Consequences
 
 * JSON data does not invalidate with URI changes in `$schema`, provoked by any change of folders or filenames
 * JSON data still decodes its version by `formatVersion`
 * Ever version of a JSON schema corresponds to a single file
 * Name `ABCD.json` is still possible, for example for a generated JSON schema that encodes all versions
-* The type `enum` suits the purpose of validation (preferred over string)
+* The type `const` suits the purpose of validation of a single value (preferred over `enum`)
 
-### Negative Consequences <!-- optional -->
+### Negative Consequences
 
-* Build in validation and annotation, of JSON data, in editors like eclipse or vs Code is based on `$schema` and is not accessible out-of-the box
+* Build in validation and annotation, of JSON data, in editors like eclipse or VS Code is based on `$schema` and is not accessible out-of-the box
 * The logic of assigning JSON data to its JSON schema has to be provided by a third party, since it is no longer possible to resolve the URI in the JSON data
+* Change type of `const` to number is bad, because for JSON schema the following representation of integer `1` are equivalent: `1`, `1.0`, `1.00`, ...
 
 
 ## Other Options
 In the discussions we discarded the following options.
+
 
 ### [option 1]
 
 Versioning by file name
 — | Instance | Schema
 :--- | :--- | :---
-File name | xy.chko-v.1.json | chko-v.1.json
+File name | name.ABCD-v1.json | ABCD-v1.json
 
 * Bad, because moving to the next version does rename the JSON data file
 * Bad, as the JSON data itself should know about the version
@@ -73,16 +75,9 @@ As decides, but without field `formatVersion` or `version`.
 * Bad, the version information should be easily retrievable, not by decoding URIs
 
 
-### [option 3]
 
-[example | description | pointer to more information | …] <!-- optional -->
+## Links
 
-* Good, because [argument a]
-* Good, because [argument b]
-* Bad, because [argument c]
-* … <!-- numbers of pros and cons can vary -->
-
-## Links <!-- optional -->
-
-* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
-* … <!-- numbers of links can vary -->
+* Discussion of whether put `$schema` into data or not https://github.com/json-schema/json-schema/issues/220
+* Catalog of collection of common JSON Schema on https://www.schemastore.org/api/json/catalog.json
+* Documentation of JSON editing, validation and annotation in VS Code https://vscode.readthedocs.io/en/latest/languages/json/

--- a/doc/decision-log/0001-json-version.md
+++ b/doc/decision-log/0001-json-version.md
@@ -31,7 +31,7 @@ JSON schema:
 
 ## Decision Outcome
 
-In the context of ABAP, `version` ambiguous as it suggests 'in-/active' versions.
+In the context of ABAP, `version` is ambiguous as it suggests 'in-/active' versions.
 Instead we agreed on `formatVersion`.
 Together with the JSON schema annotation, this is considered to be precise.
 
@@ -43,13 +43,13 @@ The JSON version is declared as const on root level.
 
 * JSON data does not invalidate with URI changes in `$schema`, provoked by any change of folders or filenames
 * JSON data still decodes its version by `formatVersion`
-* Ever version of a JSON schema corresponds to a single file
+* Every version of a JSON schema corresponds to a single file
 * Name `ABCD.json` is still possible, for example for a generated JSON schema that encodes all versions
 * The type `const` suits the purpose of validation of a single value (preferred over `enum`)
 
 ### Negative Consequences
 
-* Build in validation and annotation, of JSON data, in editors like eclipse or VS Code is based on `$schema` and is not accessible out-of-the box
+* Build-in validation and annotation, of JSON data, in editors like eclipse or VS Code is based on `$schema` and is not accessible out-of-the box
 * The logic of assigning JSON data to its JSON schema has to be provided by a third party, since it is no longer possible to resolve the URI in the JSON data
 * Change type of `const` to number is bad, because for JSON schema the following representation of integer `1` are equivalent: `1`, `1.0`, `1.00`, ...
 

--- a/doc/decision-log/0001-json-version.md
+++ b/doc/decision-log/0001-json-version.md
@@ -70,7 +70,7 @@ File name | name.ABCD-v1.json | ABCD-v1.json
 
 ### [option 2]
 
-As decides, but without field `formatVersion` or `version`.
+As decided, but without field `formatVersion` or `version`.
 
 * Bad, the version information should be easily retrievable, not by decoding URIs
 

--- a/doc/decision-log/0001-json-version.md
+++ b/doc/decision-log/0001-json-version.md
@@ -25,7 +25,7 @@ JSON data:
 
 JSON schema:
 * Declare field `version` as `const` located on root level
-1. Name `ABCD-v1.json` or `ABCD-v.1.json` for the first version of the JSON schema for ABAP object type `ABCD`
+1. Name `ABCD-v1.json` for the first version of the JSON schema for ABAP object type `ABCD`
 2. Store all versions in `ABCD.json` and resolve the version inside by JSON schema logic
 
 
@@ -49,7 +49,7 @@ The JSON version is declared as const on root level.
 
 ### Negative Consequences
 
-* Build-in validation and annotation, of JSON data, in editors like eclipse or VS Code is based on `$schema` and is not accessible out-of-the box
+* Build-in validation and annotation of JSON data in editors like Eclipse or VS Code is based on `$schema` and is not accessible out-of-the box
 * The logic of assigning JSON data to its JSON schema has to be provided by a third party, since it is no longer possible to resolve the URI in the JSON data
 * Change type of `const` to number is bad, because for JSON schema the following representation of integer `1` are equivalent: `1`, `1.0`, `1.00`, ...
 

--- a/doc/decision-log/index.md
+++ b/doc/decision-log/index.md
@@ -1,0 +1,8 @@
+# Decision Log
+
+This log lists the decisions for ABAP file formats.
+
+<!-- source: https://adr.github.io/madr/ -->
+
+* [ADR-0001](0001-json-version.md) - JSON Versioning
+* [Template](template.md) - [short title of solved problem and solution]

--- a/doc/decision-log/template.md
+++ b/doc/decision-log/template.md
@@ -1,0 +1,72 @@
+# [short title of solved problem and solution]
+
+* Status: [proposed | rejected | accepted | deprecated | … | superseded by decision 0042 ] <!-- optional -->
+* Deciders: [list everyone involved in the decision] <!-- optional -->
+* Date: [YYYY-MM-DD when the decision was last updated] <!-- optional -->
+
+Technical Story: [description | ticket/issue URL] <!-- optional -->
+
+## Context and Problem Statement
+
+[Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.]
+
+## Decision Drivers <!-- optional -->
+
+* [driver 1, e.g., a force, facing concern, …]
+* [driver 2, e.g., a force, facing concern, …]
+* … <!-- numbers of drivers can vary -->
+
+## Considered Options
+
+* [option 1]
+* [option 2]
+* [option 3]
+* … <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
+
+### Positive Consequences <!-- optional -->
+
+* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
+* …
+
+### Negative Consequences <!-- optional -->
+
+* [e.g., compromising quality attribute, follow-up decisions required, …]
+* …
+
+## Pros and Cons of the Options <!-- optional -->
+
+### [option 1]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+### [option 2]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+### [option 3]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+## Links <!-- optional -->
+
+* [Link type] [Link to ADR] <!-- example: Refined by ... -->
+* … <!-- numbers of links can vary -->


### PR DESCRIPTION
The Markdown documents provide information of design decision of the `versioning` of JSON files in ABAP file formats.
It contains the considered alternative options and pros/cons we discussed.
It contains discussions from #53

It also includes a index.md as a landing page for further design decision documents