### PR TITLE
fix interface name

### DIFF
--- a/file-formats/zif_aff_oo_types_v1.intf.abap
+++ b/file-formats/zif_aff_oo_types_v1.intf.abap
@@ -1,4 +1,4 @@
-INTERFACE zif_oo_aff_types_v1
+INTERFACE zif_aff_oo_types_v1
   PUBLIC.
 
   TYPES:


### PR DESCRIPTION
fix to match filename

automatic check implemented in https://github.com/abaplint/abaplint/pull/2203

this should also fix the automatic renaming/mirroring in https://github.com/abapGit/aff_mirror