### PR TITLE
INTF: update example

### DIFF
--- a/file-formats/intf/examples/z_aff_example_intf.intf.abap
+++ b/file-formats/intf/examples/z_aff_example_intf.intf.abap
@@ -9,7 +9,5 @@ INTERFACE z_aff_example_intf PUBLIC.
   "! Method description, lorem ipsum
   METHODS example_method
     IMPORTING
-      !i_param TYPE ty_example_type
-    RAISING
-      cx_static_check.
+      !i_param TYPE ty_example_type.
 ENDINTERFACE.

--- a/file-formats/intf/examples/z_aff_example_intf.intf.json
+++ b/file-formats/intf/examples/z_aff_example_intf.intf.json
@@ -32,12 +32,6 @@
             "name": "I_PARAM",
             "description": "This is an example parameter"
           }
-        ],
-        "exceptions": [
-          {
-            "name": "CX_STATIC_CHECK",
-            "description": "This is an example exception"
-          }
         ]
       }
     ]


### PR DESCRIPTION
`cx_static_check` is unknown to the linter, as it runs without deps

I think its okay to remove `cx_static_check` as its not critical to the example

found during regression test of the next abaplint version, https://github.com/abaplint/abaplint/pull/2220