### PR TITLE
Change type of bufferedNumbers to integer

### DIFF
--- a/file-formats/nrob/examples/z_aff_nr.nrob.json
+++ b/file-formats/nrob/examples/z_aff_nr.nrob.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": "1",
   "header": {
-    "description": "Aff example object for type NROB",
+    "description": "Example number range object for ABAP file formats",
     "originalLanguage": "EN"
   },
   "interval": {
@@ -9,11 +9,11 @@
     "percentWarning": 10.0,
     "subType": "",
     "untilYear": false,
-    "rolling": true,
+    "rolling": false,
     "prefix": false
   },
   "configuration": {
     "buffering": "none",
-    "bufferedNumbers": "0"
+    "bufferedNumbers": 0
   }
 }

--- a/file-formats/nrob/nrob-v1.json
+++ b/file-formats/nrob/nrob-v1.json
@@ -142,11 +142,11 @@
         },
         "bufferedNumbers": {
           "title": "Buffered Numbers",
-          "description": "This value specifies the numbers in buffer. In case of parallel and main memory buffering, add a number for \u0027bufferedNumbers\u0027. It determines how many numbers are reserved in buffer for the intervals.Default number of buffers is 10.",
-          "type": "string",
-          "maxLength": 8,
-          "pattern": "[0-9]*",
-          "default": "10"
+          "description": "This value specifies the numbers in buffer. In case of parallel and main memory buffering, add a number for \\u0027bufferedNumbers\\u0027. It determines how many numbers are reserved in buffer for the intervals.Default number of buffers is 10.",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 99999999,
+          "default": 10
         }
       },
       "additionalProperties": false,

--- a/file-formats/nrob/type/zif_aff_nrob_v1.intf.abap
+++ b/file-formats/nrob/type/zif_aff_nrob_v1.intf.abap
@@ -93,8 +93,10 @@ INTERFACE zif_aff_nrob_v1
       "! number for \u0027bufferedNumbers\u0027. It determines how many numbers are reserved in buffer for
       "!  the intervals.Default number of buffers is 10.
       "! $required
+      "! $minimum 0
+      "! $maximum 99999999
       "! $default '10'
-      buffered_numbers TYPE n LENGTH 8,
+      buffered_numbers TYPE i,
     END OF ty_configuration.
 
   TYPES:


### PR DESCRIPTION
Now, the type of bufferedNumbers is integer with minimum 0 and maximum 99999999. This corresponds to former type n length 8.