### PR TITLE
dont report abaplint errors for examples

### DIFF
--- a/abaplint.jsonc
+++ b/abaplint.jsonc
@@ -1,7 +1,7 @@
 {
   "global": {
-    "files": "/file-formats/**/*.intf.abap",
-    "exclude": [],
+    "files": "/file-formats/**/*.*",
+    "exclude": ["/examples/"],
     "skipGeneratedGatewayClasses": true,
     "skipGeneratedPersistentClasses": true,
     "skipGeneratedFunctionGroups": true,


### PR DESCRIPTION
if opening the example files in vscode, they are added to the registry and errors are shown

this should fix that no files under "/examples/" are ever taken into account

@schneidermic0 try this