### PR TITLE
Introduce file extension `.acds`

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -53,8 +53,9 @@ These files are stored in the original language of the object and the original l
 
 ABAP file formats define three file types:
 * **`.abap`** stores ABAP source code as plain text
+* **`.acds`** stores source code of ABAP core data services (CDS) as plain text
 * **`.json`** stores content of form-based editors or properties of objects, such as `originalLanguage`, `abapLanguageVersion` and others.
-Details are found in [JSON Files in ABAP File Formats](./json.md)
+Details are found in [JSON Files in ABAP File Formats](./json.md)cr
 * **`.properties`** stores translation relevant text elements as plain text
 
 


### PR DESCRIPTION
Documents the file extension `.acds` for ABAP CDS source code files.

Closes #161.