### PR TITLE
Catch exception when JSON data is not decoded

### DIFF
--- a/json-validator.py
+++ b/json-validator.py
@@ -29,6 +29,9 @@ def match_schema_instance( ):
             version = json_data["formatVersion"]
         except KeyError:
             continue
+        except TypeError:
+            # in case decoding failed
+            continue
         # match data with schema
         schema_name =  object_type + '-v'+ version + '.json'
         schema = [s for s in schemas if schema_name in s]


### PR DESCRIPTION
Logic introduced in efd04e1 did not account for broken JSON data.
The error message was set correctly, but the exception was not caught, hence no helpful validation.

Observed in #317