### PR TITLE
[ENHS] Make enum type required

### DIFF
--- a/file-formats/enhs/enhs-v1.json
+++ b/file-formats/enhs/enhs-v1.json
@@ -311,7 +311,8 @@
         "required": [
           "name",
           "description",
-          "interface"
+          "interface",
+          "instantiation"
         ]
       }
     }

--- a/file-formats/enhs/type/zif_aff_enhs_v1.intf.abap
+++ b/file-formats/enhs/type/zif_aff_enhs_v1.intf.abap
@@ -162,6 +162,7 @@ INTERFACE zif_aff_enhs_v1
       interface          TYPE zif_aff_types_v1=>ty_object_name_30,
       "! <p class="shorttext">Instantiation of the BAdI Definition</p>
       "! Instantiation of the BAdI definition
+      "! $required
       instantiation      TYPE ty_instantiation,
       "! <p class="shorttext">Single- or Multiple Use BAdI</p>
       "! Indicator whether the BAdI definition is single- or multiple usable

--- a/file-formats/zif_aff_types_v1.intf.abap
+++ b/file-formats/zif_aff_types_v1.intf.abap
@@ -8,23 +8,35 @@ INTERFACE zif_aff_types_v1 PUBLIC.
 
   "! <p class="shorttext">ABAP Language Version</p>
   "! ABAP language version
+  "! $values {@link zif_aff_types_v1.data:co_abap_language_version}
+  "! $default {@link zif_aff_types_v1.data:co_abap_language_version.standard}
   TYPES ty_abap_language_version TYPE c LENGTH 1.
+
+  "! <p class="shorttext">ABAP Language Version</p>
+  "! ABAP language version
+  "! $values {@link zif_aff_types_v1.data:co_abap_language_version_cloud}
+  "! $default {@link zif_aff_types_v1.data:co_abap_language_version_cloud.standard}
+  TYPES ty_abap_language_version_cloud TYPE c LENGTH 1.
+
+  "! <p class="shorttext">ABAP Language Version</p>
+  "! ABAP language version
+  "! $values {@link zif_aff_types_v1.data:co_abap_language_version_src}
+  "! $default {@link zif_aff_types_v1.data:co_abap_language_version_src.standard}
+  TYPES ty_abap_language_version_src TYPE c LENGTH 1.
 
   CONSTANTS:
     "! <p class="shorttext">ABAP Language Version (Source Code Objects)</p>
     "! ABAP language version for source code objects like CLAS, INTF, FUGR or PROG.
-    "! Other source code objects (f.ex. DDLS) and non-source code objects have to use
-    "! {@link zif_aff_types_v1.data:ty_abap_language_version }
     BEGIN OF co_abap_language_version_src,
       "! <p class="shorttext">Standard</p>
       "! Standard
-      standard          TYPE ty_abap_language_version VALUE 'X',
+      standard          TYPE ty_abap_language_version_src VALUE 'X',
       "! <p class="shorttext">ABAP for Key Users</p>
       "! ABAP for key user extensibility
-      key_user          TYPE ty_abap_language_version VALUE '2',
+      key_user          TYPE ty_abap_language_version_src VALUE '2',
       "! <p class="shorttext">ABAP Cloud Development</p>
       "! ABAP cloud development
-      cloud_development TYPE ty_abap_language_version VALUE '5',
+      cloud_development TYPE ty_abap_language_version_src VALUE '5',
     END OF co_abap_language_version_src.
 
   CONSTANTS:
@@ -44,14 +56,14 @@ INTERFACE zif_aff_types_v1 PUBLIC.
 
   CONSTANTS:
     "! <p class="shorttext">ABAP Language Version</p>
-    "! ABAP language version for objects which only exist for standard and cloud development
+    "! ABAP language version for objects which only exist for standard and cloud development (no key user extensibility)
     BEGIN OF co_abap_language_version_cloud,
       "! <p class="shorttext">Standard</p>
       "! Standard
-      standard          TYPE ty_abap_language_version VALUE space,
+      standard          TYPE ty_abap_language_version_cloud VALUE space,
       "! <p class="shorttext">ABAP Cloud Development</p>
       "! ABAP cloud development
-      cloud_development TYPE ty_abap_language_version VALUE '5',
+      cloud_development TYPE ty_abap_language_version_cloud VALUE '5',
     END OF co_abap_language_version_cloud.
 
   "! <p class="shorttext">Description</p>
@@ -65,6 +77,10 @@ INTERFACE zif_aff_types_v1 PUBLIC.
   "! Object name with max. length 30
   TYPES ty_object_name_30 TYPE c LENGTH 30.
 
+  "! <p class="shorttext">Original Language</p>
+  "! Original language of the ABAP object
+  TYPES ty_original_language TYPE sy-langu.
+
   TYPES:
     "! <p class="shorttext">Header for Source Code Objects</p>
     "! The header for an ABAP main object (with source code) with a description of 60 characters
@@ -73,16 +89,23 @@ INTERFACE zif_aff_types_v1 PUBLIC.
       "! Description of the ABAP object
       "! $required
       description           TYPE ty_description_60,
-      "! <p class="shorttext">Original Language</p>
-      "! Original language of the ABAP object
       "! $required
-      original_language     TYPE sy-langu,
-      "! <p class="shorttext">ABAP Language Version (Source Code Objects)</p>
-      "! ABAP language version for source code objects
-      "! $values {@link zif_aff_types_v1.data:co_abap_language_version_src}
-      "! $default {@link zif_aff_types_v1.data:co_abap_language_version_src.standard}
-      abap_language_version TYPE ty_abap_language_version,
+      original_language     TYPE ty_original_language,
+      abap_language_version TYPE ty_abap_language_version_src,
     END OF ty_header_60_src.
+
+  TYPES:
+    "! <p class="shorttext">Header for Non-Source Code Objects (no key user)</p>
+    "! The header for an ABAP main object (without source code) with a description of 60 characters (no key user)
+    BEGIN OF ty_header_60_cloud,
+      "! <p class="shorttext">Description</p>
+      "! Description of the ABAP object
+      "! $required
+      description           TYPE ty_description_60,
+      "! $required
+      original_language     TYPE ty_original_language,
+      abap_language_version TYPE ty_abap_language_version_cloud,
+    END OF ty_header_60_cloud.
 
   TYPES:
     "! <p class="shorttext">Header for Non-Source Code Objects</p>
@@ -92,14 +115,8 @@ INTERFACE zif_aff_types_v1 PUBLIC.
       "! Description of the ABAP object
       "! $required
       description           TYPE ty_description_60,
-      "! <p class="shorttext">Original Language</p>
-      "! Original language of the ABAP object
       "! $required
-      original_language     TYPE sy-langu,
-      "! <p class="shorttext">ABAP Language Version</p>
-      "! ABAP language version
-      "! $values {@link zif_aff_types_v1.data:co_abap_language_version}
-      "! $default {@link zif_aff_types_v1.data:co_abap_language_version.standard}
+      original_language     TYPE ty_original_language,
       abap_language_version TYPE ty_abap_language_version,
     END OF ty_header_60.
 
@@ -111,14 +128,8 @@ INTERFACE zif_aff_types_v1 PUBLIC.
       "! Description of the ABAP object
       "! $required
       description           TYPE ty_description_100,
-      "! <p class="shorttext">Original Language</p>
-      "! Original language of the ABAP object
       "! $required
-      original_language     TYPE sy-langu,
-      "! <p class="shorttext">ABAP Language Version</p>
-      "! ABAP language version
-      "! $values {@link zif_aff_types_v1.data:co_abap_language_version}
-      "! $default {@link zif_aff_types_v1.data:co_abap_language_version.standard}
+      original_language     TYPE ty_original_language,
       abap_language_version TYPE ty_abap_language_version,
     END OF ty_header_100.
 


### PR DESCRIPTION
In ENHS, an enum type without a default or initial component was used. I suggest to make the component required.