### PR TITLE
Update documentation for overwriting enum values

### DIFF
--- a/docs/json.md
+++ b/docs/json.md
@@ -160,7 +160,7 @@ If not the transformed name of a component shall be used, the enum value can be 
 ```abap
 "! $enumValue 'newEnumValue'
 ```
-to the specific component. 
+to the specific component.
 
 Titles and descriptions of the enum values are passed to the JSON Schema in the same way as described above.
 They are written in the fields `enumTitles` and `enumDescriptions`.

--- a/docs/json.md
+++ b/docs/json.md
@@ -155,6 +155,13 @@ The type specifies the underlying data type and links to the constant via the fo
 ```
 The names of the components of the constant are written as external (JSON) values to the JSON Schema after being transformed to camel case (e.g, component `badi_definition` is transformed to the enum value `badiDefinition` in the JSON Schema).
 The corresponding values of the components represent the internal (ABAP) values.
+
+If not the transformed name of a component shall be used, the enum value can be overwritten by adding an ABAP Doc comment with the annotational keyword
+```abap
+"! $enumValue 'newEnumValue'
+```
+to the specific component. 
+
 Titles and descriptions of the enum values are passed to the JSON Schema in the same way as described above.
 They are written in the fields `enumTitles` and `enumDescriptions`.
 

--- a/docs/json.md
+++ b/docs/json.md
@@ -161,6 +161,7 @@ If not the transformed name of a component shall be used, the enum value can be 
 "! $enumValue 'newEnumValue'
 ```
 to the specific component.
+However, we recommend to use this feature for overwriting the enum values rarely.
 
 Titles and descriptions of the enum values are passed to the JSON Schema in the same way as described above.
 They are written in the fields `enumTitles` and `enumDescriptions`.


### PR DESCRIPTION
Now, enum values can be overwritten by using an annotation. I updated the documentation to describe the procedure

closes #312