### PR TITLE
Use ABAP CDS Syntax Highlighter for .acds files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.acds linguist-language=ABAP CDS


### PR DESCRIPTION
With github/linguist#4614 Github understands "asddls" files and uses
the syntax coloring provided by
https://github.com/FreHu/abap-cds-grammar

Let's use an override for this repo so that acds files just use the
existing coloring for "asddls".
This is explained in:
https://github.com/github/linguist/blob/master/docs/overrides.md

Fixes: #371