### PR TITLE
New header without ABAP language version

### DIFF
--- a/abaplint.jsonc
+++ b/abaplint.jsonc
@@ -194,7 +194,7 @@
     "unsecure_fae": true,
     "unused_methods": true,
     "unused_types": {
-      "skipNames": ["ty_main"]
+      "skipNames": ["ty_main", "ty_header_60_no_abap_lv"]
     },
     "unused_variables": true,
     "use_bool_expression": true,

--- a/file-formats/zif_aff_types_v1.intf.abap
+++ b/file-formats/zif_aff_types_v1.intf.abap
@@ -115,6 +115,17 @@ INTERFACE zif_aff_types_v1 PUBLIC.
     END OF ty_header_60.
 
   TYPES:
+    "! <p class="shorttext">Header</p>
+    "! The header for an ABAP main object (without source code; without ABAP language  version)
+    "! with a description of 60 characters
+    BEGIN OF ty_header_60_no_abap_lv,
+      "! $required
+      description           TYPE ty_description_60,
+      "! $required
+      original_language     TYPE ty_original_language,
+    END OF ty_header_60_no_abap_lv.
+
+  TYPES:
     "! <p class="shorttext">Header for Non-Source Code Objects</p>
     "! The header for an ABAP main object (without source code) with a description of 100 characters
     BEGIN OF ty_header_100,

--- a/file-formats/zif_aff_types_v1.intf.abap
+++ b/file-formats/zif_aff_types_v1.intf.abap
@@ -116,7 +116,7 @@ INTERFACE zif_aff_types_v1 PUBLIC.
 
   TYPES:
     "! <p class="shorttext">Header</p>
-    "! The header for an ABAP main object (without source code; without ABAP language  version)
+    "! The header for an ABAP main object (without source code; without ABAP language version)
     "! with a description of 60 characters
     BEGIN OF ty_header_60_no_abap_lv,
       "! $required


### PR DESCRIPTION
Object type CFDF needs a header without ABAP language version.

See #401 