### PR TITLE
run less actions

### DIFF
--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -15,10 +15,10 @@ name: EditorConfig
 # Start the job on all push #
 #############################
 on:
-  push:
-    branches-ignore: [main]
   pull_request:
-    branches: [main]
+
+permissions:
+  contents: read
 
 ###############
 # Set the Job #
@@ -26,6 +26,7 @@ on:
 jobs:
   lint-editorconfig:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     name: Lint for editorconfig violations
     steps:
       - name: Checkout the repository

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,16 +1,17 @@
 name: Check Markdown links
 
 on:
-  push:
-    branches-ignore: [main]
   pull_request:
-    branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@main
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
-              base-branch: 'main'
+        base-branch: 'main'

--- a/.github/workflows/py-validation.yml
+++ b/.github/workflows/py-validation.yml
@@ -1,11 +1,10 @@
 name: Validate JSON
 
 on:
-  push:
-    branches-ignore: [main]
-    # Remove the line above to run when pushing to master
   pull_request:
-    branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -13,6 +12,8 @@ jobs:
     name: Validate JSON with python jsonschema
 
     runs-on: ubuntu-latest
+
+    timeout-minutes: 10
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
check markdown + editorconfig + json actions:

only run on pull request, note that the these checks are required, plus its required that branches are up to date, and main is protected

ie. its only needed to run on pull request

this gives 3 action results,
![image](https://user-images.githubusercontent.com/5888506/201032542-8544dd42-6e3e-46f1-85a1-e1ca8402a9fd.png)

instead of 6,
![image](https://user-images.githubusercontent.com/5888506/201032664-5692d7cf-4c61-43b4-ae32-e8b624126da5.png)

for each commit

plus set permissions and timeout