### PR TITLE
DDLS: Use Official Terms for "sourceType" Attribute

### DIFF
--- a/file-formats/ddls/ddls-v1.json
+++ b/file-formats/ddls/ddls-v1.json
@@ -105,7 +105,7 @@
       "description": "Source Type",
       "type": "string",
       "enum": [
-        "view",
+        "ddicBasedView",
         "viewEntity",
         "viewExtend",
         "viewEntityExtend",
@@ -117,7 +117,7 @@
         "projectionView"
       ],
       "enumTitles": [
-        "View",
+        "DDIC-Based Views",
         "View Entity",
         "View Extend",
         "View Entity Extend",
@@ -129,7 +129,7 @@
         "Projection View"
       ],
       "enumDescriptions": [
-        "View",
+        "DDIC-Based Views",
         "View Entity",
         "View Extend",
         "View Entity Extend",

--- a/file-formats/ddls/type/zif_aff_ddls_v1.intf.abap
+++ b/file-formats/ddls/type/zif_aff_ddls_v1.intf.abap
@@ -15,9 +15,9 @@ INTERFACE zif_aff_ddls_v1
     "! <p class="shorttext">Source Type</p>
     "! Source type
     BEGIN OF co_source_type,
-      "! <p class="shorttext">View</p>
-      "! View
-      view               TYPE ty_source_type VALUE 'V',
+      "! <p class="shorttext">DDIC-Based Views</p>
+      "! DDIC-Based Views
+      ddic_based_view    TYPE ty_source_type VALUE 'V',
       "! <p class="shorttext">View Entity</p>
       "! View Entity
       view_entity        TYPE ty_source_type VALUE 'W',


### PR DESCRIPTION
The official term for source type "v" is "DDIC-Based Views". So let's also use it here.