### PR TITLE
Improved error messages for missing "formatVersion"

### DIFF
--- a/.github/workflows/py-validation.yml
+++ b/.github/workflows/py-validation.yml
@@ -1,4 +1,4 @@
-name: Validate JSON example
+name: Validate JSON examples
 
 on:
   pull_request:

--- a/.github/workflows/py-validation.yml
+++ b/.github/workflows/py-validation.yml
@@ -1,4 +1,4 @@
-name: Validate JSON data
+name: Validate JSON example
 
 on:
   pull_request:
@@ -9,7 +9,7 @@ permissions:
 jobs:
   build:
     # Name the Job
-    name: Validate data against JSON schema
+    name: Validate JSON examples against their schema
 
     runs-on: ubuntu-latest
 

--- a/json-validator.py
+++ b/json-validator.py
@@ -29,7 +29,7 @@ def match_schema_instance( ):
         try:
             version = json_data["formatVersion"]
         except KeyError:
-            msg_errors.append(f"::error file={instance},line={1},col={1}::JSON data does not provide a formatVersion")
+            msg_errors.append(f"::error file={instance},line={1},col={1}::JSON example does not specify the field \"formatVersion\"")
             continue
         except TypeError:
             # in case decoding failed


### PR DESCRIPTION
I suggest to change the error message for a missing field "formatVersion" to "JSON Example does not specify the field "formatVersion"".

Additionally, let's rename improve the action title.

Refs #479