### PR TITLE
[FUGR] Set enum defaults for compatibility

### DIFF
--- a/file-formats/fugr/func-v1.json
+++ b/file-formats/fugr/func-v1.json
@@ -47,7 +47,8 @@
         "normal",
         "rfc",
         "update"
-      ]
+      ],
+      "default": "normal"
     },
     "rfcProperties": {
       "title": "RFC Specific Fields",
@@ -80,7 +81,8 @@
             "From same system",
             "From any system",
             "Not classified"
-          ]
+          ],
+          "default": "notClassified"
         },
         "rfcVersion": {
           "title": "RFC Version",
@@ -97,7 +99,8 @@
           "enumDescriptions": [
             "Fast serialization required",
             "Any"
-          ]
+          ],
+          "default": "any"
         },
         "abapFromJava": {
           "title": "ABAP From Java",
@@ -151,7 +154,8 @@
             "Start immediately no restart",
             "Collective Run",
             "Unsupported Kind"
-          ]
+          ],
+          "default": "startImmediately"
         }
       },
       "additionalProperties": false,

--- a/file-formats/fugr/reps-v1.json
+++ b/file-formats/fugr/reps-v1.json
@@ -49,7 +49,8 @@
       "enumDescriptions": [
         "Include",
         "Function group"
-      ]
+      ],
+      "default": "include"
     }
   },
   "additionalProperties": false,

--- a/file-formats/fugr/type/zif_aff_func_v1.intf.abap
+++ b/file-formats/fugr/type/zif_aff_func_v1.intf.abap
@@ -24,6 +24,7 @@ INTERFACE zif_aff_func_v1
   "! <p class="shorttext">Processing Type</p>
   "! Processing type
   "! $values {@link zif_aff_func_v1.data:co_processing_type}
+  "! $default {@link zif_aff_func_v1.data:co_processing_type.normal}
   TYPES ty_processing_type TYPE c LENGTH 1.
 
   CONSTANTS:
@@ -45,6 +46,7 @@ INTERFACE zif_aff_func_v1
   "! <p class="shorttext">RFC Scope</p>
   "! Indicates the scope of function module calls
   "! $values {@link zif_aff_func_v1.data:co_rfc_scope}
+  "! $default {@link zif_aff_func_v1.data:co_rfc_scope.not_classified}
   TYPES ty_rfc_scope TYPE c LENGTH 1.
 
   CONSTANTS:
@@ -68,6 +70,7 @@ INTERFACE zif_aff_func_v1
   "! <p class="shorttext">RFC Version</p>
   "! Indicates the permitted serializations for the function module
   "! $values {@link zif_aff_func_v1.data:co_rfc_version}
+  "! $default {@link zif_aff_func_v1.data:co_rfc_version.any}
   TYPES ty_rfc_version TYPE c LENGTH 10.
 
   CONSTANTS:
@@ -117,6 +120,7 @@ INTERFACE zif_aff_func_v1
   "! <p class="shorttext">Update Task Kind</p>
   "! Update task kind
   "! $values {@link zif_aff_func_v1.data:co_update_task_kind}
+  "! $default {@link zif_aff_func_v1.data:co_update_task_kind.start_immediately}
   TYPES ty_update_task_kind TYPE c LENGTH 1.
 
   CONSTANTS:

--- a/file-formats/fugr/type/zif_aff_reps_v1.intf.abap
+++ b/file-formats/fugr/type/zif_aff_reps_v1.intf.abap
@@ -4,6 +4,7 @@ INTERFACE zif_aff_reps_v1
   "! <p class="shorttext">Include Type</p>
   "! Include type
   "! $values {@link zif_aff_reps_v1.data:co_include_type}
+  "! $default {@link zif_aff_reps_v1.data:co_include_type.include}
   TYPES ty_include_type TYPE c LENGTH 1.
 
   CONSTANTS:


### PR DESCRIPTION
For REPS and FUNC, defaults for the enums are set. This allows compatible extensions of the enum values.