### PR TITLE
[EVTB] Update files for increased bo_operation length

### DIFF
--- a/file-formats/evtb/evtb-v1.json
+++ b/file-formats/evtb/evtb-v1.json
@@ -89,7 +89,7 @@
       "title": "Business Object Operation",
       "description": "Business object operation",
       "type": "string",
-      "maxLength": 18
+      "maxLength": 30
     },
     "producerType": {
       "title": "Type",

--- a/file-formats/evtb/type/zif_aff_evtb_v1.intf.abap
+++ b/file-formats/evtb/type/zif_aff_evtb_v1.intf.abap
@@ -65,7 +65,7 @@ INTERFACE zif_aff_evtb_v1
       "! <p class="shorttext">Business Object Operation</p>
       "! Business object operation
       "! $required
-      bo_operation       TYPE c LENGTH 18,
+      bo_operation       TYPE c LENGTH 30,
 
       "! <p class="shorttext">Type</p>
       "! Type


### PR DESCRIPTION
The length of field `bo_operation `is increased from 18 to 30 characters. 

A downport (e.g. via abapGit) of an event binding to an onPremise system with an outdated JSON schema for object type Event Binding will fail, if the bo_operation length exceeds 18 characters. 
Should this need arise, the necessary update to the JSON Schema and AFF interface will be provided in the form of a note.
