### PR TITLE
Add header for cloud with description 100

### DIFF
--- a/file-formats/zif_aff_types_v1.intf.abap
+++ b/file-formats/zif_aff_types_v1.intf.abap
@@ -135,7 +135,7 @@ INTERFACE zif_aff_types_v1 PUBLIC.
       original_language     TYPE ty_original_language,
       abap_language_version TYPE ty_abap_language_version,
     END OF ty_header_100.
-  
+
   TYPES:
     "! <p class="shorttext">Header for Non-Source Code Objects (no key user)</p>
     "! The header for an ABAP main object (without source code) with a description of 100 characters (no key user)

--- a/file-formats/zif_aff_types_v1.intf.abap
+++ b/file-formats/zif_aff_types_v1.intf.abap
@@ -135,6 +135,17 @@ INTERFACE zif_aff_types_v1 PUBLIC.
       original_language     TYPE ty_original_language,
       abap_language_version TYPE ty_abap_language_version,
     END OF ty_header_100.
+  
+  TYPES:
+    "! <p class="shorttext">Header for Non-Source Code Objects (no key user)</p>
+    "! The header for an ABAP main object (without source code) with a description of 100 characters (no key user)
+    BEGIN OF ty_header_100_cloud,
+      "! $required
+      description           TYPE ty_description_100,
+      "! $required
+      original_language     TYPE ty_original_language,
+      abap_language_version TYPE ty_abap_language_version_cloud,
+    END OF ty_header_100_cloud.
 
   TYPES:
     "! <p class="shorttext">Header for Subobjects</p>


### PR DESCRIPTION
Added new header that allows descriptions of length 100 and has ABAP Language Version "standard" and "cloudDevelopment"