### PR TITLE
WIP: Idea for handling of translations: Using same JSON structure for translation files

### DIFF
--- a/file-formats/chko/examples/z_aff_example_chko.chko.de.json
+++ b/file-formats/chko/examples/z_aff_example_chko.chko.de.json
@@ -1,0 +1,12 @@
+{
+  "formatVersion": "1",
+  "header": {
+    "description": "Beispiel CHKO für ABAP file formats"
+  },
+  "parameters": [
+    {
+      "name": "ParameterName",
+      "description": "Parameter Beschreibung"
+    }
+  ]
+}

--- a/file-formats/chkv/examples/z_aff_example_chkv.chkv.de.json
+++ b/file-formats/chkv/examples/z_aff_example_chkv.chkv.de.json
@@ -1,0 +1,6 @@
+{
+  "formatVersion": "1",
+  "header": {
+    "description": "Beispiel CHKV für ABAP file formats"
+  }
+}

--- a/file-formats/ddls/examples/z_aff_example_ddls.ddls.de.json
+++ b/file-formats/ddls/examples/z_aff_example_ddls.ddls.de.json
@@ -1,0 +1,6 @@
+{
+  "formatVersion": "1",
+  "header": {
+    "description": "Beispiel DDLs für ABAP file formats"
+  }
+}

--- a/file-formats/doma/examples/z_aff_example_doma.doma.de.json
+++ b/file-formats/doma/examples/z_aff_example_doma.doma.de.json
@@ -1,0 +1,16 @@
+{
+  "formatVersion": "1",
+  "header": {
+    "description": "Beispiel DOMA für ABAP file formats"
+  },
+  "fixedValues": [
+    {
+      "fixedValue": "ABC",
+      "description": "Festwert ABC"
+    },
+    {
+      "fixedValue": "XYZ",
+      "description": "Festwert XYZ"
+    }
+  ]
+}

--- a/file-formats/enhs/examples/z_aff_example_enhs.enhs.de.json
+++ b/file-formats/enhs/examples/z_aff_example_enhs.enhs.de.json
@@ -1,0 +1,18 @@
+{
+  "formatVersion": "1",
+  "header": {
+    "description": "Beispiel ENHS für ABAP file formats"
+  },
+  "badiDefinitions": [
+    {
+      "name": "Z_AFF_EXAMPLE_BADI_DEFINITION",
+      "description": "Das ist eine Bespiel-Badi-Definition",
+      "filters": [
+        {
+          "name": "EXAMPLE_FILTER",
+          "description": "Das ist ein Beispiel-Filter"
+        }
+      ]
+    }
+  ]
+}

--- a/file-formats/intf/examples/z_aff_example_intf.intf.de.json
+++ b/file-formats/intf/examples/z_aff_example_intf.intf.de.json
@@ -1,0 +1,38 @@
+{
+  "formatVersion": "1",
+  "header": {
+    "description": "Beispiel-Interface für ABAP file formats"
+  },
+  "descriptions": {
+    "types": [
+      {
+        "name": "TY_EXAMPLE_TYPE",
+        "description": "Das ist ein Beispiel-Typ"
+      }
+    ],
+    "attributes": [
+      {
+        "name": "CO_EXAMPLE_CONSTANT",
+        "description": "Das ist eine Beispiel-Konstante"
+      }
+    ],
+    "events": [
+      {
+        "name": "EXAMPLE_EVENT",
+        "description": "Das ist ein Beispiel-Event"
+      }
+    ],
+    "methods": [
+      {
+        "name": "EXAMPLE_METHOD",
+        "description": "Das ist eine Beispiel-Methode",
+        "parameters": [
+          {
+            "name": "I_PARAM",
+            "description": "Das ist ein Beispiel-Paramter"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
See #106. 

This PR shall show one possible approach how translations could be stored in separate JSON files (one file per language and JSON file). 

The filename pattern would be `<object name>.<object type>.<language>.json`.

The content of the JSON file shows following fields of the original ABAP file format (JSON representation):

- `formatVersion`
- all language-dependent fields
- all key fields to identify an item in an array
