### PR TITLE
WIP: Idea for handling of translations: Using PO files

### DIFF
--- a/file-formats/chko/examples/z_aff_example_chko.chko.de.po
+++ b/file-formats/chko/examples/z_aff_example_chko.chko.de.po
@@ -1,0 +1,14 @@
+#, fuzzy
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: header.description 
+msgid "Example CHKO for ABAP file formats"
+msgstr "Beispiel CHKO für ABAP file formats"
+
+#: parameters[ParameterName]
+msgid "Paramter description"
+msgstr "Parameter Beschreibung"

--- a/file-formats/chkv/examples/z_aff_example_chkv.chkv.de.po
+++ b/file-formats/chkv/examples/z_aff_example_chkv.chkv.de.po
@@ -1,0 +1,10 @@
+#, fuzzy
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: header.description 
+msgid "Example CHKV for ABAP file formats"
+msgstr "Beispiel CHKV für ABAP file formats"

--- a/file-formats/ddls/examples/z_aff_example_ddls.ddls.de.po
+++ b/file-formats/ddls/examples/z_aff_example_ddls.ddls.de.po
@@ -1,0 +1,10 @@
+#, fuzzy
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: header.description 
+msgid "Example DDLs for ABAP file formats"
+msgstr "Beispiel DDLs für ABAP file formats"

--- a/file-formats/doma/examples/z_aff_example_doma.doma.de.po
+++ b/file-formats/doma/examples/z_aff_example_doma.doma.de.po
@@ -1,0 +1,18 @@
+#, fuzzy
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: header.description 
+msgid "Example DOMA for ABAP file formats"
+msgstr "Beispiel DOMA für ABAP file formats"
+
+#: fixedValues[ABC]
+msgid "Fixed value ABC"
+msgstr "Festwert ABC"
+
+#: fixedValues[XYZ]
+msgid "Fixed value XYZ"
+msgstr "Festwert XYZ"

--- a/file-formats/intf/examples/z_aff_example_intf.intf.de.po
+++ b/file-formats/intf/examples/z_aff_example_intf.intf.de.po
@@ -1,0 +1,30 @@
+#, fuzzy
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: header.description 
+msgid "Example interface for ABAP file formats"
+msgstr "Beispiel Interface für ABAP file formats"
+
+#: descriptions.types[TY_EXAMPLE_TYPE]
+msgid "This is an example type"
+msgstr "Das ist ein Beispiel-Typ"
+
+#: descriptions.attributes[CO_EXAMPLE_CONSTANT]
+msgid "This is an example constant"
+msgstr "Das ist eine Beispiel-Konstante"
+
+#: descriptions.events[EXAMPLE_EVENT]
+msgid "This is an example event"
+msgstr "Das ist ein Beispiel-Event"
+
+#: descriptions.methods[EXAMPLE_METHOD]
+msgid "This is an example method"
+msgstr "Das ist eine Beispiel-Methode"
+
+#: descriptions.methods[EXAMPLE_METHOD].paramters[I_PARAM]
+msgid "This is an example paramter"
+msgstr "Das ist ein Beispiel-Parameter"


### PR DESCRIPTION
See https://github.com/SAP/abap-file-formats/issues/106

This PR shall show one possible approach how translations could be stored in separate .po files (one file per language) as suggested by @sbcgua in https://github.com/abapGit/abapGit/issues/2539.

The filename pattern would be `<object name>.<object type>.<language>.po`.

The keys are the texts to be translated.

Example:

```
#: object.array[arrayKey].field
msgid "Text in original language"
msgstr "Translated text"
```