### PR TITLE
[RONT] Delete expanded name

### DIFF
--- a/file-formats/ront/examples/z_aff_example_ront.ront.json
+++ b/file-formats/ront/examples/z_aff_example_ront.ront.json
@@ -6,6 +6,5 @@
   },
   "typeCategory": "businessObject",
   "name": "Z_Aff_Example_Ront",
-  "expandedName": "Z_Aff_Example_Ront_Expanded",
-  "objectTypeCode": "12345"
+  "objectTypeCode": "4789"
 }

--- a/file-formats/ront/ront-v1.json
+++ b/file-formats/ront/ront-v1.json
@@ -87,12 +87,6 @@
       "type": "string",
       "maxLength": 30
     },
-    "expandedName": {
-      "title": "Expanded Name",
-      "description": "The expanded name of the SAP Object Type is its unabbreviated name.",
-      "type": "string",
-      "maxLength": 512
-    },
     "objectTypeCode": {
       "title": "Object Type Code",
       "description": "The object type code uniquely identifies the SAP Object Type.",
@@ -105,7 +99,6 @@
     "formatVersion",
     "header",
     "typeCategory",
-    "name",
-    "expandedName"
+    "name"
   ]
 }

--- a/file-formats/ront/type/zif_aff_ront_v1.intf.abap
+++ b/file-formats/ront/type/zif_aff_ront_v1.intf.abap
@@ -43,11 +43,6 @@ INTERFACE zif_aff_ront_v1
       "! $required
       name             TYPE c LENGTH 30,
 
-      "! <p class="shorttext">Expanded Name</p>
-      "! The expanded name of the SAP Object Type is its unabbreviated name.
-      "! $required
-      expanded_name    TYPE c LENGTH 512,
-
       "! <p class="shorttext">Object Type Code</p>
       "! The object type code uniquely identifies the SAP Object Type.
       object_type_code TYPE c LENGTH 5,


### PR DESCRIPTION
The expanded name has become obsolete and is therefore removed from the AFF Interface of object type RONT.