### PR TITLE
Catch exception if json schema not found

### DIFF
--- a/json-validator.py
+++ b/json-validator.py
@@ -42,7 +42,11 @@ def match_schema_to_data( ):
         example_version = decode_json( example )[ 'formatVersion' ]
         json_schema = [ schema for schema in schemas if example_type in os.path.basename(schema).split( sep = '-' )[0]
                                                         and example_version in os.path.basename(schema).split( sep='-')[1]]
-        match[example] = json_schema.pop( 0 )
+        try:
+            match[example] = json_schema.pop( 0 )
+        except IndexError:
+            msg_errors.append(f"no JSON Schema found for example {os.path.basename(example)}")
+
     return match
 
 def validate_examples( matches ):


### PR DESCRIPTION
Will provide a message, instead of abortion, for the error in #526 (example name missing object type).