### PR TITLE
Rename field root_node_flag and delete obsolete expanded_name

### DIFF
--- a/file-formats/nont/examples/z_aff_example_nont.nont.json
+++ b/file-formats/nont/examples/z_aff_example_nont.nont.json
@@ -4,7 +4,6 @@
     "description": "Example SAP Object Node Type.",
     "originalLanguage": "en"
   },
-  "name": "Z_Aff_Example_Nont",
-  "expandedName": "Z_Aff_Example_Nont_Expanded",
+  "name": "Z_AFF_EXAMPLE_NONT",
   "sapObjectType": "Z_Aff_Example_Ront"
 }

--- a/file-formats/nont/nont-v1.json
+++ b/file-formats/nont/nont-v1.json
@@ -60,20 +60,14 @@
       "type": "string",
       "maxLength": 30
     },
-    "expandedName": {
-      "title": "Expanded Name",
-      "description": "The expanded name of the SAP Object Node Type is its unabbreviated name.",
-      "type": "string",
-      "maxLength": 512
-    },
     "sapObjectType": {
       "title": "SAP Object Type",
       "description": "The name of the referenced SAP Object Type.",
       "type": "string",
       "maxLength": 30
     },
-    "rootNodeFlag": {
-      "title": "Root Node Flag",
+    "rootNode": {
+      "title": "Root Node",
       "description": "Indicates that the SAP Object Node Type corresponds to the referenced SAP Object Type.",
       "type": "boolean"
     }
@@ -82,7 +76,6 @@
   "required": [
     "formatVersion",
     "header",
-    "name",
-    "expandedName"
+    "name"
   ]
 }

--- a/file-formats/nont/type/zif_aff_nont_v1.intf.abap
+++ b/file-formats/nont/type/zif_aff_nont_v1.intf.abap
@@ -17,18 +17,13 @@ INTERFACE zif_aff_nont_v1
       "! $required
       name            TYPE c LENGTH 30,
 
-      "! <p class="shorttext">Expanded Name</p>
-      "! The expanded name of the SAP Object Node Type is its unabbreviated name.
-      "! $required
-      expanded_name   TYPE c LENGTH 512,
-
       "! <p class="shorttext">SAP Object Type</p>
       "! The name of the referenced SAP Object Type.
       sap_object_type TYPE c LENGTH 30,
 
-      "! <p class="shorttext">Root Node Flag</p>
+      "! <p class="shorttext">Root Node</p>
       "! Indicates that the SAP Object Node Type corresponds to the referenced SAP Object Type.
-      root_node_flag  TYPE abap_bool,
+      root_node  TYPE abap_bool,
 
     END OF ty_main.
 


### PR DESCRIPTION
* the boolean root_node_flag field is renamed to root_node in the AFF interface.
* the obsolelete expanded name is removed from the ABAP File Format for SAP Object Node Type (NONT) 