### PR TITLE
Make generated JSON Schema available in PR

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -19,3 +19,6 @@ jobs:
       run: |
         cd generate
         npm run generate
+    - name: Output generate JSON Schema
+      run: |
+        find generate/generated -name '*.json' -print -exec cat {} \; -exec echo \;


### PR DESCRIPTION
Just paste all generated schema into the log of the GitHub Action. Could be improved by pasting only the schema of the specific object type, that is contained in PR.