### PR TITLE
[SCP1]Remove "Software Component" related fields

### DIFF
--- a/file-formats/scp1/scp1-v1.json
+++ b/file-formats/scp1/scp1-v1.json
@@ -77,24 +77,6 @@
             "A hierarchical BC Set comprises several other BC Sets, which can also be hierarchical. The hierarchy can have any number of levels"
           ],
           "default": "simple"
-        },
-        "softwareComponent": {
-          "title": "Software Component",
-          "description": "BC Set is assigned to a software component. If the software component is not installed in the system, then activation of BC Set is aborted",
-          "type": "string",
-          "maxLength": 30
-        },
-        "minimumRelease": {
-          "title": "Minimum Release",
-          "description": "To activate the BC Set successfully, installed software component must be at least at this release",
-          "type": "string",
-          "maxLength": 10
-        },
-        "maximumRelease": {
-          "title": "Maximum Release",
-          "description": "To activate the BC Set successfully, installed software component must be within this release",
-          "type": "string",
-          "maxLength": 10
         }
       },
       "additionalProperties": false

--- a/file-formats/scp1/type/zif_aff_scp1_v1.intf.abap
+++ b/file-formats/scp1/type/zif_aff_scp1_v1.intf.abap
@@ -17,16 +17,6 @@ INTERFACE zif_aff_scp1_v1
       hierarchical TYPE ty_type VALUE 'TMP',
     END OF co_type.
 
-  "! <p class="shorttext">Release</p>
-  TYPES ty_release TYPE c LENGTH 10.
-
-  CONSTANTS:
-    "! <p class="shorttext">Validity</p>
-    BEGIN OF co_validity,
-      "! <p class="shorttext">All Releases</p>
-      all_releases TYPE ty_release VALUE '*',
-    END OF co_validity.
-
   TYPES:
     "! <p class="shorttext">Attribute</p>
     "! Attributes of BC Set
@@ -36,16 +26,6 @@ INTERFACE zif_aff_scp1_v1
       "! $values {@link zif_aff_scp1_v1.data:co_type}
       "! $default {@link zif_aff_scp1_v1.data:co_type.simple}
       type               TYPE ty_type,
-      "! <p class="shorttext">Software Component</p>
-      "! BC Set is assigned to a software component. If the software component is not installed in the system,
-      "! then activation of BC Set is aborted
-      software_component TYPE c LENGTH 30,
-      "! <p class="shorttext">Minimum Release</p>
-      "! To activate the BC Set successfully, installed software component must be at least at this release
-      minimum_release    TYPE ty_release,
-      "! <p class="shorttext">Maximum Release</p>
-      "! To activate the BC Set successfully, installed software component must be within this release
-      maximum_release    TYPE ty_release,
     END OF ty_attributes.
 
   "! <p class="shorttext">Customizing Object Type</p>


### PR DESCRIPTION
Initially we decided to keep "Software Component", "Minimum Release" and "Maximum Release" fields that can be maintained for BC Sets. Because of Software Components are being merged, the code split from S/4 and the issues raised while activating a BC Sets in Steampunk environment, we decided not to keep these fields in AFF.

@wurzka had requested to upload a simple example with lesser in file size. So I will create a seperate PR for the same soon.