### PR TITLE
[SAJC] Add title, screen element and radiobutton group to parameters

### DIFF
--- a/file-formats/sajc/README.md
+++ b/file-formats/sajc/README.md
@@ -1,5 +1,5 @@
 # SAJC File Format
 
 File | Cardinality | Definition | Schema | Example
-:--- | :---  | :--- | :--- | :---
-`<name>.sajc.json` | 1 | [`zif_aff_sajc_v1.intf.abap`](./type/zif_aff_sajc_v1.intf.abap) | [`sajc-v1.json`](./sajc-v1.json) | [`z_aff_example_sajc.sajc.json`](./examples/z_aff_example_sajc.sajc.json)
+:--- | :--- | :--- | :--- | :---
+`<name>.sajc.json` | 1 |  [`zif_aff_sajc_v1.intf.abap`](./type/zif_aff_sajc_v1.intf.abap)  | [`sajc-v1.json`](./sajc-v1.json) | [z_aff_example_sajc.sajc.json](./examples/z_aff_example_sajc.sajc.json)

--- a/file-formats/sajc/README.md
+++ b/file-formats/sajc/README.md
@@ -2,4 +2,4 @@
 
 File | Cardinality | Definition | Schema | Example
 :--- | :--- | :--- | :--- | :---
-`<name>.sajc.json` | 1 |  [`zif_aff_sajc_v1.intf.abap`](./type/zif_aff_sajc_v1.intf.abap)  | [`sajc-v1.json`](./sajc-v1.json) | [z_aff_example_sajc.sajc.json](./examples/z_aff_example_sajc.sajc.json)
+`<name>.sajc.json` | 1 | [`zif_aff_sajc_v1.intf.abap`](./type/zif_aff_sajc_v1.intf.abap) | [`sajc-v1.json`](./sajc-v1.json) | [`z_aff_example_sajc.sajc.json`](./examples/z_aff_example_sajc.sajc.json)

--- a/file-formats/sajc/examples/z_aff_example_sajc.sajc.json
+++ b/file-formats/sajc/examples/z_aff_example_sajc.sajc.json
@@ -10,8 +10,7 @@
   "exitClasses": {
     "check": "CL_APJ_HOME_DEMO_CHECK",
     "valueHelp": "CL_VALUE_HELP_APJ_SIMPLE",
-    "notification": "CL_APJ_HOME_DEMO_CHECK",
-    "delete": "CL_APJT_RT_JOB_DELETE_EXIT"
+    "notification": "CL_APJ_HOME_DEMO_CHECK"
   },
   "sections": [
     {

--- a/file-formats/sajc/sajc-v1.json
+++ b/file-formats/sajc/sajc-v1.json
@@ -101,12 +101,6 @@
           "description": "Name of the class which contains the notification exit",
           "type": "string",
           "maxLength": 30
-        },
-        "delete": {
-          "title": "Delete",
-          "description": "Name of the class which contains the delete exit",
-          "type": "string",
-          "maxLength": 30
         }
       },
       "additionalProperties": false
@@ -190,6 +184,12 @@
             "type": "string",
             "maxLength": 38
           },
+          "title": {
+            "title": "Title",
+            "description": "Title of the parameter on the selection screen",
+            "type": "string",
+            "maxLength": 255
+          },
           "group": {
             "title": "Group",
             "description": "Name of the parameter group",
@@ -221,6 +221,36 @@
             "description": "Name of the boolean parameter which enables / disables the current parameter",
             "type": "string",
             "maxLength": 38
+          },
+          "screenElement": {
+            "title": "Screen Element",
+            "description": "Display of the parameter as screen element (radio button, checkbox, list box)",
+            "type": "string",
+            "enum": [
+              "none",
+              "checkbox",
+              "radiobutton",
+              "listbox"
+            ],
+            "enumTitles": [
+              "None",
+              "Checkbox",
+              "Radio Button",
+              "List Box"
+            ],
+            "enumDescriptions": [
+              "None",
+              "Checkbox",
+              "Radio button",
+              "List box"
+            ],
+            "default": "none"
+          },
+          "radiobuttonGroup": {
+            "title": "Radio Button Group",
+            "description": "Name of the radio button group if the parameter is a radio button",
+            "type": "string",
+            "maxLength": 4
           },
           "backendCall": {
             "title": "Backend Call",

--- a/file-formats/sajc/sajc-v1.json
+++ b/file-formats/sajc/sajc-v1.json
@@ -229,8 +229,8 @@
             "enum": [
               "none",
               "checkbox",
-              "radiobutton",
-              "listbox"
+              "radioButton",
+              "listBox"
             ],
             "enumTitles": [
               "None",
@@ -246,7 +246,7 @@
             ],
             "default": "none"
           },
-          "radiobuttonGroup": {
+          "radioButtonGroup": {
             "title": "Radio Button Group",
             "description": "Name of the radio button group if the parameter is a radio button",
             "type": "string",

--- a/file-formats/sajc/type/zif_aff_sajc_v1.intf.abap
+++ b/file-formats/sajc/type/zif_aff_sajc_v1.intf.abap
@@ -69,7 +69,7 @@ INTERFACE zif_aff_sajc_v1
   TYPES ty_title_text TYPE c LENGTH 120.
   "! <p class="shorttext">Radio Button Group</p>
   "! Name of the radio button group
-  TYPES ty_radiobutton_group TYPE c LENGTH 4.
+  TYPES ty_radio_button_group TYPE c LENGTH 4.
   "! <p class="shorttext">Screen Element</p>
   "! Type of the screen element
   "! $values {@link zif_aff_sajc_v1.data:co_screen_element}
@@ -82,16 +82,16 @@ INTERFACE zif_aff_sajc_v1
     BEGIN OF co_screen_element,
       "! <p class="shorttext">None</p>
       "! None
-      none        TYPE ty_screen_element VALUE ' ',
+      none         TYPE ty_screen_element VALUE ' ',
       "! <p class="shorttext">Checkbox</p>
       "! Checkbox
-      checkbox    TYPE ty_screen_element VALUE 'C',
+      checkbox     TYPE ty_screen_element VALUE 'C',
       "! <p class="shorttext">Radio Button</p>
       "! Radio button
-      radiobutton TYPE ty_screen_element VALUE 'R',
+      radio_button TYPE ty_screen_element VALUE 'R',
       "! <p class="shorttext">List Box</p>
       "! List box
-      listbox     TYPE ty_screen_element VALUE 'L',
+      list_box     TYPE ty_screen_element VALUE 'L',
     END OF co_screen_element.
 
   TYPES:
@@ -128,7 +128,7 @@ INTERFACE zif_aff_sajc_v1
       screen_element       TYPE ty_screen_element,
       "! <p class="shorttext">Radio Button Group</p>
       "! Name of the radio button group if the parameter is a radio button
-      radiobutton_group    TYPE ty_radiobutton_group,
+      radio_button_group   TYPE ty_radio_button_group,
       "! <p class="shorttext">Backend Call</p>
       "! Flag indicating whether a call of the backend system is triggered after a parameter value change to check it
       backend_call         TYPE abap_bool,

--- a/file-formats/sajc/type/zif_aff_sajc_v1.intf.abap
+++ b/file-formats/sajc/type/zif_aff_sajc_v1.intf.abap
@@ -50,9 +50,6 @@ INTERFACE zif_aff_sajc_v1
       "! <p class="shorttext">Notification</p>
       "! Name of the class which contains the notification exit
       notification TYPE zif_aff_types_v1=>ty_object_name_30,
-      "! <p class="shorttext">Delete</p>
-      "! Name of the class which contains the delete exit
-      delete       TYPE zif_aff_types_v1=>ty_object_name_30,
     END OF ty_exit_classes.
 
   "! <p class="shorttext">Parameter Name</p>
@@ -64,9 +61,38 @@ INTERFACE zif_aff_sajc_v1
   "! <p class="shorttext">Section Name</p>
   "! Name of the section
   TYPES ty_section_name TYPE c LENGTH 10.
+  "! <p class="shorttext">Parameter Title Text</p>
+  "! Text of the parameter title
+  TYPES ty_parameter_title_text TYPE c LENGTH 255.
   "! <p class="shorttext">Title Text</p>
   "! Text of the title
   TYPES ty_title_text TYPE c LENGTH 120.
+  "! <p class="shorttext">Radio Button Group</p>
+  "! Name of the radio button group
+  TYPES ty_radiobutton_group TYPE c LENGTH 4.
+  "! <p class="shorttext">Screen Element</p>
+  "! Type of the screen element
+  "! $values {@link zif_aff_sajc_v1.data:co_screen_element}
+  "! $default {@link zif_aff_sajc_v1.data:co_screen_element.none}
+  TYPES ty_screen_element TYPE c LENGTH 1.
+
+  CONSTANTS:
+    "! <p class="shorttext">Screen Element</p>
+    "! Type of the screen element
+    BEGIN OF co_screen_element,
+      "! <p class="shorttext">None</p>
+      "! None
+      none        TYPE ty_screen_element VALUE ' ',
+      "! <p class="shorttext">Checkbox</p>
+      "! Checkbox
+      checkbox    TYPE ty_screen_element VALUE 'C',
+      "! <p class="shorttext">Radio Button</p>
+      "! Radio button
+      radiobutton TYPE ty_screen_element VALUE 'R',
+      "! <p class="shorttext">List Box</p>
+      "! List box
+      listbox     TYPE ty_screen_element VALUE 'L',
+    END OF co_screen_element.
 
   TYPES:
     "! <p class="shorttext">Parameter</p>
@@ -76,6 +102,9 @@ INTERFACE zif_aff_sajc_v1
       "! Name of the parameter
       "! $required
       name                 TYPE ty_parameter_name,
+      "! <p class="shorttext">Title</p>
+      "! Title of the parameter on the selection screen
+      title                TYPE ty_parameter_title_text,
       "! <p class="shorttext">Group</p>
       "! Name of the parameter group
       group                TYPE ty_group_name,
@@ -94,6 +123,12 @@ INTERFACE zif_aff_sajc_v1
       "! <p class="shorttext">Enabled By Parameter</p>
       "! Name of the boolean parameter which enables / disables the current parameter
       enabled_by_parameter TYPE ty_parameter_name,
+      "! <p class="shorttext">Screen Element</p>
+      "! Display of the parameter as screen element (radio button, checkbox, list box)
+      screen_element       TYPE ty_screen_element,
+      "! <p class="shorttext">Radio Button Group</p>
+      "! Name of the radio button group if the parameter is a radio button
+      radiobutton_group    TYPE ty_radiobutton_group,
       "! <p class="shorttext">Backend Call</p>
       "! Flag indicating whether a call of the backend system is triggered after a parameter value change to check it
       backend_call         TYPE abap_bool,
@@ -118,14 +153,14 @@ INTERFACE zif_aff_sajc_v1
       "! <p class="shorttext">Name</p>
       "! Name of the group
       "! $required
-      name     TYPE ty_group_name,
+      name    TYPE ty_group_name,
       "! <p class="shorttext">Title</p>
       "! Title of the group on the selection screen
       "! $required
-      title    TYPE ty_title_text,
+      title   TYPE ty_title_text,
       "! <p class="shorttext">Section</p>
       "! Name of the group section
-      section  TYPE ty_section_name,
+      section TYPE ty_section_name,
     END OF ty_group.
   TYPES:
     "! <p class="shorttext">Groups</p>
@@ -139,11 +174,11 @@ INTERFACE zif_aff_sajc_v1
       "! <p class="shorttext">Name</p>
       "! Name of the section
       "! $required
-      name     TYPE ty_section_name,
+      name  TYPE ty_section_name,
       "! <p class="shorttext">Title</p>
       "! Title of the section on the selection screen
       "! $required
-      title    TYPE ty_title_text,
+      title TYPE ty_title_text,
     END OF ty_section.
   TYPES:
     "! <p class="shorttext">Sections</p>


### PR DESCRIPTION
A new type of class-based application jobs is introduced. Here, the title of the parameter, the screen element which is used for the parameter and the radio button group are not set in the class any more, but in the application job catalog entry. Therefore, the application job catalog entry has to be extended.