### PR TITLE
[RONT] Add ODM Entity Name and Interface Behavior Definition to RONT AFF

### DIFF
--- a/file-formats/ront/README.md
+++ b/file-formats/ront/README.md
@@ -2,4 +2,4 @@
 
 File | Cardinality | Definition | Schema | Example
 :--- | :--- | :--- | :--- | :---
-`<name>.ront.json` | 1 |  [`zif_aff_ront_v1.intf.abap`](./type/zif_aff_ront_v1.intf.abap)  | [`ront-v1.json`](./ront-v1.json) | [z_aff_example_ront.ront.json](./examples/z_aff_example_ront.ront.json)
+`<name>.ront.json` | 1 | [`zif_aff_ront_v1.intf.abap`](./type/zif_aff_ront_v1.intf.abap) | [`ront-v1.json`](./ront-v1.json) | [`z_aff_example_ront.ront.json`](./examples/z_aff_example_ront.ront.json)

--- a/file-formats/ront/examples/z_aff_example_ront.ront.json
+++ b/file-formats/ront/examples/z_aff_example_ront.ront.json
@@ -6,5 +6,7 @@
   },
   "typeCategory": "businessObject",
   "name": "Z_Aff_Example_Ront",
-  "objectTypeCode": "4789"
+  "objectTypeCode": "4789",
+  "interfaceBehaviorDefinition": "I_EXAMPLE_INTERFACE_BEH_DEF_TP",
+  "odmEntityName": "ExampleODMEntity"
 }

--- a/file-formats/ront/ront-v1.json
+++ b/file-formats/ront/ront-v1.json
@@ -97,6 +97,18 @@
       "description": "The object type code uniquely identifies the SAP Object Type.",
       "type": "string",
       "maxLength": 5
+    },
+    "interfaceBehaviorDefinition": {
+      "title": "Interface Behavior Definition",
+      "description": "The interface behavior definition related to the SAP Object Type.",
+      "type": "string",
+      "maxLength": 30
+    },
+    "odmEntityName": {
+      "title": "ODM Entity Name",
+      "description": "The One Domain Model entity related to the SAP Object Type.",
+      "type": "string",
+      "maxLength": 255
     }
   },
   "additionalProperties": false,

--- a/file-formats/ront/type/zif_aff_ront_v1.intf.abap
+++ b/file-formats/ront/type/zif_aff_ront_v1.intf.abap
@@ -17,10 +17,10 @@ INTERFACE zif_aff_ront_v1
       configuration_object TYPE c LENGTH 2 VALUE `CO`,
       "! <p class="shorttext">Dependent Object</p>
       "! Dependent object
-      dependent_object TYPE c LENGTH 2 VALUE `DO`,
+      dependent_object     TYPE c LENGTH 2 VALUE `DO`,
       "! <p class="shorttext">Hierarchy Object</p>
       "! Hierarchy object
-      hierarchy_object TYPE c LENGTH 2 VALUE `HO`,
+      hierarchy_object     TYPE c LENGTH 2 VALUE `HO`,
     END OF co_category.
 
   TYPES:
@@ -28,28 +28,36 @@ INTERFACE zif_aff_ront_v1
     "! SAP object type
     BEGIN OF ty_main,
       "! $required
-      format_version   TYPE zif_aff_types_v1=>ty_format_version,
+      format_version                TYPE zif_aff_types_v1=>ty_format_version,
 
       "! <p class="shorttext">Header</p>
       "! Header
       "! $required
-      header           TYPE zif_aff_types_v1=>ty_header_60_cloud,
+      header                        TYPE zif_aff_types_v1=>ty_header_60_cloud,
 
       "! <p class="shorttext">Type Category</p>
       "! The category of the SAP Object Type
       "! $required
       "! $values {@link zif_aff_ront_v1.data:co_category}
       "! $default {@link zif_aff_ront_v1.data:co_category.business_object}
-      type_category    TYPE c LENGTH 2,
+      type_category                 TYPE c LENGTH 2,
 
       "! <p class="shorttext">Name</p>
       "! The name of the SAP Object Type.
       "! $required
-      name             TYPE c LENGTH 30,
+      name                          TYPE c LENGTH 30,
 
       "! <p class="shorttext">Object Type Code</p>
       "! The object type code uniquely identifies the SAP Object Type.
-      object_type_code TYPE c LENGTH 5,
+      object_type_code              TYPE c LENGTH 5,
+
+      "! <p class="shorttext">Interface Behavior Definition</p>
+      "! The interface behavior definition related to the SAP Object Type.
+      interface_behavior_definition TYPE c LENGTH 30,
+
+      "! <p class="shorttext">ODM Entity Name</p>
+      "! The One Domain Model entity related to the SAP Object Type.
+      odm_entity_name               TYPE c LENGTH 255,
 
     END OF ty_main.
 


### PR DESCRIPTION
The AFF interface for SAP Object Type (RONT) is extended by two new optional fields:
* interface_behavior_definition
* odm_entity_name

These fields make it possible to relate an existing SAP Object Type to a One Domain Model (ODM) entity and / or [Interface Behavior Definition](https://help.sap.com/doc/abapdocu_latest_index_htm/latest/en-US/abenbdl_rap_bo_interface.htm?file=abenbdl_rap_bo_interface.htm), thus enriching the SAP Object Type's integration possibilities.
