### PR TITLE
Consider modified JSON Schema only

### DIFF
--- a/compatibility-check/json-schema-diff.js
+++ b/compatibility-check/json-schema-diff.js
@@ -21,7 +21,7 @@ async function run() {
     }
   };
 
-  await exec.exec('git diff --name-only remotes/origin/main..HEAD', [], options);
+  await exec.exec('git diff --name-only --diff-filter=M remotes/origin/main..HEAD', [], options);
 
   const pattern = new RegExp('file-formats/[a-z]{4}/[a-z]+-v[0-9]+\.json$', 'i');
   const lines = stdout.split("\n");


### PR DESCRIPTION
Sort out the non-relevant JSON Schema right at the beginning, so we don't need to catch those kind of failures later. E.g. line 27-28 will be removed by this change 
<img width="990" alt="image" src="https://github.com/SAP/abap-file-formats/assets/38354196/a32a9841-6cc9-4473-aecb-a6c0b624f143">
