### PR TITLE
updated documentation for the language field

### DIFF
--- a/docs/json.md
+++ b/docs/json.md
@@ -92,7 +92,7 @@ i | integer | `"minimum": -2147483648, "maximum": 2147483647`
 n | string | `"maxLength": <length of character field>, "pattern": "^[0-9]+$"`
 p | number | `"minimum": <minimum value>, "maximum": <maximum value>
 abap_bool | boolean |
-sy-langu | string | `"minLength": 2, "maxLength": 2, "pattern": "^[a-z]+$"`
+sy-langu | string | `"minLength": 2`
 table | array | if the table has unique keys, `"uniqueItems": true` is added to the schema; hashed tables are not supported
 
 ### Title
@@ -306,9 +306,7 @@ This leads to the following generated JSON schema:
           "title": "Original Language",
           "description": "Original language of the ABAP object",
           "type": "string",
-          "minLength": 2,
-          "maxLength": 2,
-          "pattern": "^[a-z]+$"
+          "minLength": 2
         },
         "abapLanguageVersion": {
           "title": "ABAP Language Version (source code object)",
@@ -369,7 +367,7 @@ The field `description` contains the description of the object.
 
 The field `originalLanguage` stores the information about the original language of the object.
 
-The original language is specified with [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) language codes.
+The original language is specified with [BCP47](https://en.wikipedia.org/wiki/IETF_language_tag) language tags, which combine [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) language codes with subtags for language variations. 
 
 All translatable texts in the object shall be maintained in their original language.
 Translations of the texts shall be stored in separate files.

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -1,0 +1,114 @@
+## Supported languages for the Original Language field
+
+The following table shows all currently supported languages (BCP47 format) for the `originalLanguage` field and their corresponding SAP2 language code. 
+
+| Language                    | BCP47   | SAP2 | 
+|-----------------------------|---------|------| 
+| Afrikaans                   | af      | AF   | 
+| Albanian                    | sq      | SQ   | 
+| Basque                      | eu      | EU   | 
+| Bosnian                     | bs      | BS   | 
+| Bulgarian                   | bg      | BG   | 
+| Catalan                     | ca      | CA   | 
+| Chinese China               | zh      | ZH   | 
+| Chinese Singapore           | zh-SG   | 3C   | 
+| Chinese Taiwan              | zh-Hant | ZF   | 
+| Croatian                    | hr      | HR   | 
+| Czech                       | cs      | CS   | 
+| Danish                      | da      | DA   | 
+| Dutch Netherlands           | nl      | NL   | 
+| Dutch Belgium               | nl-BE   | 1D   | 
+| English United States       | en      | EN   | 
+| English United Kingdom      | en-GB   | 6N   | 
+| English Australia           | en-AU   | 1E   | 
+| English Belize              | en-BZ   | 2E   | 
+| English Canada              | en-CA   | 3E   | 
+| English Hong Kong SAR       | en-HK   | 5E   | 
+| English India               | en-IN   | 6E   | 
+| English Indonesia           | en-ID   | 7E   | 
+| English Ireland             | en-IE   | 8E   | 
+| English Jamaica             | en-JM   | 9E   | 
+| English Malaysia            | en-MY   | 0E   | 
+| English New Zealand         | en-NZ   | 1N   | 
+| English Philippines         | en-PH   | 2N   | 
+| English Singapore           | en-SG   | 3N   | 
+| English South Africa        | en-ZA   | 4N   | 
+| English Trinidad and Tobago | en-TT   | 5N   | 
+| English Zimbabwe            | en-ZW   | 7N   | 
+| Estonian                    | et      | ET   | 
+| Finnish                     | fi      | FI   | 
+| French France               | fr      | FR   | 
+| French Belgium              | fr-BE   | 1F   | 
+| French Cameroon             | fr-CM   | 2F   | 
+| French Canada               | fr-CA   | 3F   | 
+| French Congo DRC            | fr-CG   | 4F   | 
+| French Cote d'Ivoire        | fr-CI   | 5F   | 
+| French Haiti                | fr-HT   | 6F   | 
+| French Luxembourg           | fr-LU   | 7F   | 
+| French Mali                 | fr-ML   | 8F   | 
+| French Monaco               | fr-MC   | 9F   | 
+| French Morocco              | fr-MA   | 1H   | 
+| French Reunion              | fr-RE   | 2H   | 
+| French Senegal              | fr-SN   | 3H   | 
+| French Switzerland          | fr-CH   | 4H   | 
+| Gaelic                      | gd      | GD   | 
+| Gallegan                    | gl      | GL   | 
+| German Germany              | de      | DE   | 
+| German Austria              | de-AT   | 1G   | 
+| German Liechtenstein        | de-LI   | 2G   | 
+| German Luxembourg           | de-LU   | 3G   | 
+| German Switzerland          | de-CH   | 4G   | 
+| Greek, Modern               | el      | EL   | 
+| Hebrew                      | he      | HE   | 
+| Hungarian                   | hu      | HU   | 
+| Icelandic                   | is      | IS   | 
+| Indonesian                  | id      | ID   | 
+| Irish                       | ga      | GA   | 
+| Italian Italy               | it      | IT   | 
+| Italian Switzerland         | it-CH   | 1I   | 
+| Japanese                    | ja      | JA   | 
+| Korean South Korea          | ko      | KO   | 
+| Latvian                     | lv      | LV   | 
+| Lithuanian                  | lt      | LT   | 
+| Malay Malaysia              | ms      | MS   | 
+| Malay Brunei Darussalam     | ms-BN   | 1M   | 
+| Norwegian                   | no      | NO   | 
+| Polish                      | pl      | PL   | 
+| Portuguese Brazil           | pt      | PT   | 
+| Rhaeto-Romance              | rm      | RM   | 
+| Romanian Romania            | ro      | RO   | 
+| Russian Russia              | ru      | RU   | 
+| Serbian, Cyrillic           | sr-Cyrl | SR   | 
+| Serbian, Latin              | sr-Latn | SH   | 
+| Slovak                      | sk      | SK   | 
+| Slovenian                   | sl      | SL   | 
+| Sorbian                     | wen     | SB   | 
+| Lower Sorbain               | dsb     | DS   | 
+| Upper Sorbian               | hsb     | HS   | 
+| Spanish Spain               | es      | ES   | 
+| Spanish Argentina           | es-AR   | 1S   | 
+| Spanish Bolivia             | es-BO   | 2S   | 
+| Spanish Chile               | es-CL   | 3S   | 
+| Spanish Columbia            | es-CO   | 0S   | 
+| Spanish Costa Rica          | es-CR   | 4S   | 
+| Spanish Dominican Republic  | es-DO   | 5S   | 
+| Spanish Ecuador             | es-EC   | 6S   | 
+| Spanish El Salvador         | es-SV   | 7S   | 
+| Spanish Guatemala           | es-GT   | 8S   | 
+| Spanish Honduras            | es-HN   | 9S   | 
+| Spanish Mexico              | es-MX   | 1X   | 
+| Spanish Nicaragua           | es-NI   | 2X   | 
+| Spanish Panama              | es-PA   | 3X   | 
+| Spanish Paraguay            | es-PY   | 4X   | 
+| Spanish Peru                | es-PE   | 5X   | 
+| Spanish Puerto Rico         | es-PR   | 6X   | 
+| Spanish Uruguay             | es-UY   | 7X   | 
+| Spanish Venezuela           | es-VE   | 8X   | 
+| Swahili                     | sw      | SW   | 
+| Swedish                     | sv      | SV   | 
+| Tagalog                     | tl      | TL   | 
+| Thai                        | th      | TH   | 
+| Turkish                     | tr      | TR   | 
+| Ukrainian                   | uk      | UK   | 
+| Vietnamese                  | vi      | VI   | 
+| Walloon                     | wa      | WA   | 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -42,7 +42,7 @@ cl_oo_clif_source.clas.texts.en.properties
 ```
 
 ### Language
-The language of the texts is encoded by the element `language` following [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
+The language of the texts is encoded by the element `language` following [BCP47](https://en.wikipedia.org/wiki/IETF_language_tag).
 ```
 cl_oo_clif_source.clas.texts.en.properties
 ```


### PR DESCRIPTION
Updates documentation according to changes made for #582 and adds a table for all supported languages and their BCP47 language code. 

Follow up to #607 