### PR TITLE
Fix incorrect example in docs/json.md documentation

### DIFF
--- a/docs/json.md
+++ b/docs/json.md
@@ -135,7 +135,7 @@ followed by a space and the desired value are used.
 In order to express constraints to the values of a field, it is possible to pass regular expressions enclosed in single quotes:
 
 ```abap
-"! $pattern '<regex pattern, i.e. [a-Z]*>'
+"! $pattern '<regex pattern, i.e. [a-z]*>'
 ```
 The complete syntax of regular expressions is not widely supported, therefore it is recommended to stick on the subset described [here](https://json-schema.org/understanding-json-schema/reference/regular_expressions).
 


### PR DESCRIPTION
In the example I used for the pattern annotation I had a typo in the pattern; [a-Z]* is not a valid regex, therefore I changed it to [a-z]*