### PR TITLE
Add yml to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@
 root = true
 
 # ensure the LF line endings
-[*.{abap,md,properties,acds,json,mjs,gitignore}]
+[*.{abap,md,properties,acds,json,mjs,gitignore,yml}]
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true


### PR DESCRIPTION
Your GitHub Actions are defined in YML files which shall have an empty line as EOF marker.