### PR TITLE
[AIFR] - Adding field aifRecipient to AFF for AIFR

### DIFF
--- a/file-formats/aifr/aifr-v1.json
+++ b/file-formats/aifr/aifr-v1.json
@@ -65,7 +65,7 @@
           "type": "string",
           "maxLength": 15
         },
-        "aifRecipientName": {
+        "aifRecipient": {
           "title": "AIF Recipient",
           "description": "SAP Application Interface recipient",
           "type": "string",
@@ -75,7 +75,7 @@
       "additionalProperties": false,
       "required": [
         "namespace",
-        "aifRecipientName"
+        "aifRecipient"
       ]
     }
   },

--- a/file-formats/aifr/aifr-v1.json
+++ b/file-formats/aifr/aifr-v1.json
@@ -64,11 +64,18 @@
           "description": "Namespace of the recipient",
           "type": "string",
           "maxLength": 15
+        },
+        "aifRecipientName": {
+          "title": "AIF Recipient",
+          "description": "SAP Application Interface recipient",
+          "type": "string",
+          "maxLength": 25
         }
       },
       "additionalProperties": false,
       "required": [
-        "namespace"
+        "namespace",
+        "aifRecipientName"
       ]
     }
   },

--- a/file-formats/aifr/examples/z_aff_example_aifr.aifr.json
+++ b/file-formats/aifr/examples/z_aff_example_aifr.aifr.json
@@ -6,6 +6,7 @@
     "abapLanguageVersion": "cloudDevelopment"
   },
   "generalInformation":{
-      "namespace": "AIFNS"
+      "namespace": "AIFNS",
+      "aifRecipientName": "REC_WS_INB"
   }
 }

--- a/file-formats/aifr/examples/z_aff_example_aifr.aifr.json
+++ b/file-formats/aifr/examples/z_aff_example_aifr.aifr.json
@@ -7,6 +7,6 @@
   },
   "generalInformation":{
       "namespace": "AIFNS",
-      "aifRecipientName": "REC_WS_INB"
+      "aifRecipient": "REC_WS_INB"
   }
 }

--- a/file-formats/aifr/type/zif_aff_aifr_v1.intf.abap
+++ b/file-formats/aifr/type/zif_aff_aifr_v1.intf.abap
@@ -11,7 +11,7 @@ INTERFACE zif_aff_aifr_v1
       "! <p class="shorttext">AIF Recipient</p>
       "! SAP Application Interface recipient
       "! $required
-      aif_recipient TYPE c LENGTH 25,  "/AIF/RECIPIENT_NAME
+      aif_recipient TYPE c LENGTH 25, 
     END OF ty_general_information,
 
     "! <p class="shorttext">Recipient</p>

--- a/file-formats/aifr/type/zif_aff_aifr_v1.intf.abap
+++ b/file-formats/aifr/type/zif_aff_aifr_v1.intf.abap
@@ -7,7 +7,11 @@ INTERFACE zif_aff_aifr_v1
       "! <p class="shorttext">Namespace</p>
       "! Namespace of the recipient
       "! $required
-      namespace TYPE c LENGTH 15,
+      namespace          TYPE c LENGTH 15,
+      "! <p class="shorttext">AIF Recipient</p>
+      "! SAP Application Interface recipient
+      "! $required
+      aif_recipient_name TYPE c LENGTH 25,  "/AIF/RECIPIENT_NAME
     END OF ty_general_information,
 
     "! <p class="shorttext">Recipient</p>

--- a/file-formats/aifr/type/zif_aff_aifr_v1.intf.abap
+++ b/file-formats/aifr/type/zif_aff_aifr_v1.intf.abap
@@ -11,7 +11,7 @@ INTERFACE zif_aff_aifr_v1
       "! <p class="shorttext">AIF Recipient</p>
       "! SAP Application Interface recipient
       "! $required
-      aif_recipient TYPE c LENGTH 25, 
+      aif_recipient TYPE c LENGTH 25,
     END OF ty_general_information,
 
     "! <p class="shorttext">Recipient</p>

--- a/file-formats/aifr/type/zif_aff_aifr_v1.intf.abap
+++ b/file-formats/aifr/type/zif_aff_aifr_v1.intf.abap
@@ -7,11 +7,11 @@ INTERFACE zif_aff_aifr_v1
       "! <p class="shorttext">Namespace</p>
       "! Namespace of the recipient
       "! $required
-      namespace          TYPE c LENGTH 15,
+      namespace     TYPE c LENGTH 15,
       "! <p class="shorttext">AIF Recipient</p>
       "! SAP Application Interface recipient
       "! $required
-      aif_recipient_name TYPE c LENGTH 25,  "/AIF/RECIPIENT_NAME
+      aif_recipient TYPE c LENGTH 25,  "/AIF/RECIPIENT_NAME
     END OF ty_general_information,
 
     "! <p class="shorttext">Recipient</p>


### PR DESCRIPTION
Short explanation of the background:
During our tests, we discovered the need for an additional field in the AIFR, specifically the AIF Recipient. 
It must be possible to assign the same AIF recipient to different namespaces.

The object name is derived from the namespace and the AIF Recipient. To ensure accurate derivation, we include both fields in the creation wizard and set the object name as read-only.
Since the exact derivation from object name Recipient back to Namespace and AIF Recipient may not always be possible, we displayed both fields as read-only in the editor for informational purposes.