### PR TITLE
Temporary fix for linkspector GitHub action

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   check-links:
     name: Check links
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Downgrading action runner to ubuntu 22.04 as proposed in https://github.com/UmbrellaDocs/action-linkspector/issues/32.

It seems like a fix is already proposed for the GitHub action, but it is not merged yet: https://github.com/UmbrellaDocs/action-linkspector/pull/34.