### PR TITLE
Update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -22,7 +22,7 @@ jobs:
         npm run generate
     - name: Upload generated schemas
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: schemas
         path: |


### PR DESCRIPTION
> Starting January 30th, 2025, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact)

see https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

I've updated this to v4, but do we really need to save the generated schemas in the action? The only thing this does is to save the generated schemas in the action workflow (e.g. [here](https://github.com/SAP/abap-file-formats/actions/runs/13035151280), scroll to the bottom). 

fixes issue in #677 