### PR TITLE
Increase Version for `tj-actions/changed-files` from 44 to 46

### DIFF
--- a/.github/workflows/example-not-delted.yml
+++ b/.github/workflows/example-not-delted.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Get deleted files
       id: changed-files
-      uses: tj-actions/changed-files@v44
+      uses: tj-actions/changed-files@v46
       with:
         files: "file-formats/*/examples/*"
 


### PR DESCRIPTION
Increase version for `tj-actions/changed-files` from 44 to 46. 

Fixes https://github.com/SAP/abap-file-formats/security/dependabot/13