### PR TITLE
chore: Change from tj-actions/changed-files to step-security/changed-files

### DIFF
--- a/.github/workflows/example-not-delted.yml
+++ b/.github/workflows/example-not-delted.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Get deleted files
       id: changed-files
-      uses: tj-actions/changed-files@v46
+      uses: step-security/changed-files@v45.0.1
       with:
         files: "file-formats/*/examples/*"
 


### PR DESCRIPTION
As tj-actions owners did not prove to have safeguarded their organization, it is better to not trust the organization anymore.