### PR TITLE
Update npm dependencies and fix syntax

### DIFF
--- a/generate/cl_run.clas.abap
+++ b/generate/cl_run.clas.abap
@@ -4,7 +4,7 @@ CLASS cl_run DEFINITION PUBLIC FINAL CREATE PUBLIC.
       IMPORTING
         main_object_type   TYPE string
         sub_object_type   TYPE string
-        format_version TYPE string
+        format_version TYPE i
       RETURNING
         VALUE(result) TYPE string.
 ENDCLASS.
@@ -19,6 +19,7 @@ CLASS cl_run IMPLEMENTATION.
     DATA schema_id  TYPE string.
     DATA ref        TYPE REF TO data.
     FIELD-SYMBOLS <row> LIKE LINE OF string_tab.
+    FIELD-SYMBOLS <ref> TYPE any.
 
     schema_id = |https://github.com/SAP/abap-file-formats/blob/main/file-formats/{ to_lower( main_object_type ) }/{ to_lower( sub_object_type ) }-v{ format_version }.json|.
     type_name = to_upper( |ZIF_AFF_{ sub_object_type }_V{ format_version }=>TY_MAIN| ).
@@ -34,7 +35,8 @@ CLASS cl_run IMPLEMENTATION.
       EXPORTING
         writer = writer.
 
-    string_tab = generator->zif_aff_generator~generate_type( ref->* ).
+    ASSIGN ref->* TO <ref>.
+    string_tab = generator->zif_aff_generator~generate_type( <ref> ).
 
 * workaround for transpiler/JS keywords
     LOOP AT string_tab ASSIGNING <row>.
@@ -43,7 +45,7 @@ CLASS cl_run IMPLEMENTATION.
       ENDIF.
     ENDLOOP.
 
-    CONCATENATE LINES OF string_tab INTO result SEPARATED BY |\n|.
+    CONCATENATE LINES OF string_tab INTO result SEPARATED BY cl_abap_char_utilities=>newline.
   ENDMETHOD.
 
 ENDCLASS.

--- a/generate/package-lock.json
+++ b/generate/package-lock.json
@@ -9,36 +9,39 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@abaplint/database-sqlite": "^2.7.96",
-        "@abaplint/runtime": "^2.7.100",
-        "@abaplint/transpiler-cli": "^2.7.100",
-        "@actions/core": "^1.10.1",
-        "oras-pull": "^0.1.5"
+        "@abaplint/database-sqlite": "^2.10.24",
+        "@abaplint/runtime": "^2.10.75",
+        "@abaplint/transpiler-cli": "^2.10.75",
+        "@actions/core": "^1.11.1",
+        "oras-pull": "^0.1.7"
       }
     },
     "node_modules/@abaplint/database-sqlite": {
-      "version": "2.7.119",
-      "resolved": "https://registry.npmjs.org/@abaplint/database-sqlite/-/database-sqlite-2.7.119.tgz",
-      "integrity": "sha512-WAXKQaVk+ehJnuQw7kpPEAHnfmtosyW5cU8l46ylitb04DyVmMPlZ8SBJTOygPByvFyKnDUupu7fiLENocNy+A==",
+      "version": "2.10.24",
+      "resolved": "https://registry.npmjs.org/@abaplint/database-sqlite/-/database-sqlite-2.10.24.tgz",
+      "integrity": "sha512-Ra6sMIOLjDwdSQ8HKHnninvBhY305L1QEemATPq+TZYV1kwUwSFZ/dkj+Sc0Cx3uuGL2s0f3VqJrM/fJGZzaag==",
+      "license": "MIT",
       "dependencies": {
-        "sql.js": "^1.8.0"
+        "sql.js": "^1.11.0"
       }
     },
     "node_modules/@abaplint/runtime": {
-      "version": "2.7.136",
-      "resolved": "https://registry.npmjs.org/@abaplint/runtime/-/runtime-2.7.136.tgz",
-      "integrity": "sha512-w8//A4ee3/zrqGft3Mckr7KyqtwMOdIPobfoCEzqTpL2wziGlgtp9GHoMZX1e/x3EtbiLWwxfJCGHvERag59ig==",
+      "version": "2.10.75",
+      "resolved": "https://registry.npmjs.org/@abaplint/runtime/-/runtime-2.10.75.tgz",
+      "integrity": "sha512-3DQ8m6g3J3HVboqFgiOzIoSw5fG4bAMHodOZ+gE2WAARGlwj7HU1My/4wQXSX2pJeyAFgso3kDd1BlNwiVEjwQ==",
+      "license": "MIT",
       "dependencies": {
-        "temporal-polyfill": "^0.1.1"
+        "temporal-polyfill": "^0.2.5"
       },
       "funding": {
         "url": "https://github.com/sponsors/larshp"
       }
     },
     "node_modules/@abaplint/transpiler-cli": {
-      "version": "2.7.136",
-      "resolved": "https://registry.npmjs.org/@abaplint/transpiler-cli/-/transpiler-cli-2.7.136.tgz",
-      "integrity": "sha512-baVz9h7zij90+T5fxCN3aHVxQh0Up2+ICybTakleZLDSMgRzkpq8LQ+lmNRK44suAadrc74WDvWJ7OODlcJnyA==",
+      "version": "2.10.75",
+      "resolved": "https://registry.npmjs.org/@abaplint/transpiler-cli/-/transpiler-cli-2.10.75.tgz",
+      "integrity": "sha512-kal/PIj7ShL30Jtoi9Buf/S1zKfGw+bho4+vhXU/GbjvsqMZw7l8+EpfuKg3714QIBruxipRELxTmmdYGro7GQ==",
+      "license": "MIT",
       "bin": {
         "abap_transpile": "abap_transpile"
       },
@@ -47,27 +50,45 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.1.tgz",
-      "integrity": "sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
+      "license": "MIT",
       "dependencies": {
-        "@actions/http-client": "^2.0.1",
-        "uuid": "^8.3.2"
+        "@actions/exec": "^1.1.1",
+        "@actions/http-client": "^2.0.1"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/io": "^1.0.1"
       }
     },
     "node_modules/@actions/http-client": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.0.tgz",
-      "integrity": "sha512-q+epW0trjVUUHboliPb4UF9g2msf+w61b32tAkFEwL/IwP0DQWgbCMM0Hbe3e3WXSKz5VcUXbzJQgy8Hkra/Lg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
+      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+      "license": "MIT",
       "dependencies": {
         "tunnel": "^0.0.6",
         "undici": "^5.25.4"
       }
     },
+    "node_modules/@actions/io": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
+      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
+      "license": "MIT"
+    },
     "node_modules/@fastify/busboy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
-      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
       "engines": {
         "node": ">=14"
       }
@@ -76,22 +97,25 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "license": "ISC",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/cross-fetch": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
-      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "license": "MIT",
       "dependencies": {
-        "node-fetch": "^2.6.12"
+        "node-fetch": "^2.7.0"
       }
     },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -103,6 +127,7 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -114,6 +139,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
       "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "license": "ISC",
       "engines": {
         "node": ">=8"
       }
@@ -122,6 +148,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "license": "MIT",
       "dependencies": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -134,6 +161,7 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -145,6 +173,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -156,6 +185,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -172,26 +202,29 @@
       }
     },
     "node_modules/oras-pull": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/oras-pull/-/oras-pull-0.1.5.tgz",
-      "integrity": "sha512-0PyOnupaG7OSQvC591GRSrA0cUEcWUZ7eahDBEMSpOPpHuikwD5gG51RhCb+uwOyvfDo+8DteyvseCzRijV5+A==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/oras-pull/-/oras-pull-0.1.7.tgz",
+      "integrity": "sha512-ACixBJ6ks2FP8bbQzHH6kgxPlhfDwet+ivbzp5UrEGACWMGAYNs6TbGNx631yYZclK0mYeTMeo3mtrJS5Ub36A==",
+      "license": "MIT",
       "dependencies": {
-        "cross-fetch": "^3.1.5",
-        "tar": "^6.1.13"
+        "cross-fetch": "^4.1.0",
+        "tar": "^6.2.1"
       },
       "bin": {
         "oras-pull": "oras-pull"
       }
     },
     "node_modules/sql.js": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.9.0.tgz",
-      "integrity": "sha512-+QMN8NU5KJxofT+lEaSLYdhh+Pdq7ZYS6X5bSbpmD+4SKFf+qBmr+coKT07LZ+keUNh1sf3Nz9dQwD8WNI2i/Q=="
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.13.0.tgz",
+      "integrity": "sha512-RJbVP1HRDlUUXahJ7VMTcu9Rm1Nzw+EBpoPr94vnbD4LwR715F3CcxE2G2k45PewcaZ57pjetYa+LoSJLAASgA==",
+      "license": "MIT"
     },
     "node_modules/tar": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
       "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "license": "ISC",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -205,27 +238,31 @@
       }
     },
     "node_modules/temporal-polyfill": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.1.1.tgz",
-      "integrity": "sha512-/5e4EVRA0wBI/bEhWLirSjwUg1lELhQyTXxw9zNbVhqjKvI9BLczs+3wtsoD9sn3HN2ImAMW5XJQwAiXgWT+GA==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.2.5.tgz",
+      "integrity": "sha512-ye47xp8Cb0nDguAhrrDS1JT1SzwEV9e26sSsrWzVu+yPZ7LzceEcH0i2gci9jWfOfSCCgM3Qv5nOYShVUUFUXA==",
+      "license": "MIT",
       "dependencies": {
-        "temporal-spec": "~0.1.0"
+        "temporal-spec": "^0.2.4"
       }
     },
     "node_modules/temporal-spec": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.1.0.tgz",
-      "integrity": "sha512-sMNggMeS6trCgMQuudgFHhX1gtBK3e+AT1zGrMsFYG1wlqtRT5E9rcvm3I1iNlvHpJX/3DO6L4qtWAuEl/T04Q=="
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.2.4.tgz",
+      "integrity": "sha512-lDMFv4nKQrSjlkHKAlHVqKrBG4DyFfa9F74cmBZ3Iy3ed8yvWnlWSIdi4IKfSqwmazAohBNwiN64qGx4y5Q3IQ==",
+      "license": "ISC"
     },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
@@ -242,23 +279,17 @@
         "node": ">=14.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -267,7 +298,8 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     }
   }
 }

--- a/generate/package.json
+++ b/generate/package.json
@@ -22,10 +22,10 @@
   },
   "homepage": "https://github.com/SAP/abap-file-formats#readme",
   "dependencies": {
-    "@abaplint/database-sqlite": "^2.7.96",
-    "@abaplint/runtime": "^2.7.100",
-    "@abaplint/transpiler-cli": "^2.7.100",
-    "@actions/core": "^1.10.1",
-    "oras-pull": "^0.1.5"
+    "@abaplint/database-sqlite": "^2.10.24",
+    "@abaplint/runtime": "^2.10.75",
+    "@abaplint/transpiler-cli": "^2.10.75",
+    "@actions/core": "^1.11.1",
+    "oras-pull": "^0.1.7"
   }
 }


### PR DESCRIPTION
Github Action for comparing generated with provided JSON schema broke due to some dependency updates in abap-file-format-tools and the abaplint transpiler (see https://github.com/SAP/abap-file-formats/actions/runs/16568936840/job/46856004071?pr=713).

After updating the npm dependencies in this repository too, the transpiler reported new syntax errors in the `cl_run` class. Are this intended side effects or regression bugs from the transpiler @larshp?

After fixing the syntax errors, the GitHub Action is working again.