### PR TITLE
Fix and improve ABAP Doc casing check action

### DIFF
--- a/.github/workflows/abap-doc-casing.yml
+++ b/.github/workflows/abap-doc-casing.yml
@@ -46,59 +46,34 @@ jobs:
       id: casing
       run: |
         git diff origin/${{ steps.pr.outputs.base }}...${{ steps.pr.outputs.sha }} -- '*.abap' \
-          | python3 scripts/check_abap_doc_casing.py --pr-diff > /tmp/casing_output.txt 2>&1
-        echo "exit_code=$?" >> "$GITHUB_OUTPUT"
-        cat /tmp/casing_output.txt
+          | python3 scripts/check_abap_doc_casing.py --pr-diff --json > /tmp/casing_output.json 2>&1 || true
 
     - name: Post result comment
       if: always()
       run: |
         python3 << 'EOF'
-        import json, os, re, subprocess, sys
+        import json, os, subprocess, sys
 
         sha  = os.environ['PR_SHA']
         pr   = os.environ['PR_NUM']
         repo = os.environ['GH_REPO']
 
-        violation_re = re.compile(r'^(.+):(\d+): (.+)$')
-        detail_re    = re.compile(r'(?:title not Title Case|description not sentence case): "(.+)" -> "(.+)"$')
-        comments = []
         try:
-            with open('/tmp/casing_output.txt') as f:
-                for line in f:
-                    m = violation_re.match(line.strip())
-                    if not m:
-                        continue
-                    path, lineno, msg = m.group(1), int(m.group(2)), m.group(3)
-                    # Build a suggestion block: read the file line, replace old text with new
-                    suggestion = None
-                    d = detail_re.search(msg)
-                    if d:
-                        old_text, new_text = d.group(1), d.group(2)
-                        try:
-                            with open(path) as src:
-                                file_lines = src.readlines()
-                            raw = file_lines[lineno - 1].rstrip('\n')
-                            fixed = raw.replace(old_text, new_text, 1)
-                            if fixed != raw:
-                                suggestion = fixed
-                        except (OSError, IndexError):
-                            pass
-                    comments.append({
-                        'path': path,
-                        'line': lineno,
-                        'msg':  msg,
-                        'suggestion': suggestion,
-                    })
-        except FileNotFoundError:
-            pass
+            comments = json.loads(open('/tmp/casing_output.json').read())
+        except (FileNotFoundError, json.JSONDecodeError):
+            comments = None
+
+        if comments is None:
+            body = "## ABAP Doc Casing Check\n\nCasing check did not run — an earlier step failed."
+            subprocess.run(['gh', 'pr', 'comment', pr, '--body', body], check=True)
+            sys.exit(0)
 
         # Post each violation as an inline review comment with suggestion
         for c in comments:
-            if c['suggestion'] is not None:
-                body = f"**Casing violation:** {c['msg']}\n\n```suggestion\n{c['suggestion']}\n```"
+            if 'suggestion' in c:
+                body = f"**Casing violation:** {c['message']}\n\n```suggestion\n{c['suggestion']}\n```"
             else:
-                body = f"**Casing violation:** {c['msg']}"
+                body = f"**Casing violation:** {c['message']}"
             payload = json.dumps({
                 'commit_id': sha,
                 'path': c['path'],
@@ -125,11 +100,7 @@ jobs:
                 f"for known product names/acronyms."
             )
         else:
-            try:
-                output = open('/tmp/casing_output.txt').read().strip()
-                body = "## ABAP Doc Casing Check\n\nAll ABAP Doc casing checks passed. ✓"
-            except FileNotFoundError:
-                body = "## ABAP Doc Casing Check\n\nCasing check did not run — an earlier step failed."
+            body = "## ABAP Doc Casing Check\n\nAll ABAP Doc casing checks passed. ✓"
 
         subprocess.run(['gh', 'pr', 'comment', pr, '--body', body], check=True)
         EOF

--- a/.github/workflows/abap-doc-casing.yml
+++ b/.github/workflows/abap-doc-casing.yml
@@ -53,23 +53,88 @@ jobs:
     - name: Post result comment
       if: always()
       run: |
-        OUTPUT=$(cat /tmp/casing_output.txt 2>/dev/null || echo "Casing check did not run — an earlier step failed.")
-        if echo "$OUTPUT" | grep -q "casing violation"; then
-          BODY="## ABAP Doc Casing Check
+        python3 << 'EOF'
+        import json, os, re, subprocess, sys
 
-        \`/check-casing\` found violations:
+        sha  = os.environ['PR_SHA']
+        pr   = os.environ['PR_NUM']
+        repo = os.environ['GH_REPO']
 
-        \`\`\`
-        $OUTPUT
-        \`\`\`
+        violation_re = re.compile(r'^(.+):(\d+): (.+)$')
+        detail_re    = re.compile(r'(?:title not Title Case|description not sentence case): "(.+)" -> "(.+)"$')
+        comments = []
+        try:
+            with open('/tmp/casing_output.txt') as f:
+                for line in f:
+                    m = violation_re.match(line.strip())
+                    if not m:
+                        continue
+                    path, lineno, msg = m.group(1), int(m.group(2)), m.group(3)
+                    # Build a suggestion block: read the file line, replace old text with new
+                    suggestion = None
+                    d = detail_re.search(msg)
+                    if d:
+                        old_text, new_text = d.group(1), d.group(2)
+                        try:
+                            with open(path) as src:
+                                file_lines = src.readlines()
+                            raw = file_lines[lineno - 1].rstrip('\n')
+                            fixed = raw.replace(old_text, new_text, 1)
+                            if fixed != raw:
+                                suggestion = fixed
+                        except (OSError, IndexError):
+                            pass
+                    comments.append({
+                        'path': path,
+                        'line': lineno,
+                        'msg':  msg,
+                        'suggestion': suggestion,
+                    })
+        except FileNotFoundError:
+            pass
 
-        Fix the violations or add terms to \`scripts/casing-terms.json\` for known product names/acronyms."
-        else
-          BODY="## ABAP Doc Casing Check
+        # Post each violation as an inline review comment with suggestion
+        for c in comments:
+            if c['suggestion'] is not None:
+                body = f"**Casing violation:** {c['msg']}\n\n```suggestion\n{c['suggestion']}\n```"
+            else:
+                body = f"**Casing violation:** {c['msg']}"
+            payload = json.dumps({
+                'commit_id': sha,
+                'path': c['path'],
+                'line': c['line'],
+                'side': 'RIGHT',
+                'body': body,
+            })
+            r = subprocess.run(
+                ['gh', 'api', f'repos/{repo}/pulls/{pr}/comments',
+                 '--method', 'POST', '--input', '-'],
+                input=payload, text=True, capture_output=True,
+            )
+            if r.returncode != 0:
+                print(f"Warning: could not post inline comment: {r.stderr.strip()}", file=sys.stderr)
 
-        All ABAP Doc casing checks passed. ✓"
-        fi
-        gh pr comment ${{ github.event.issue.number }} --body "$BODY"
+        # Post summary PR comment
+        n = len(comments)
+        if n > 0:
+            body = (
+                f"## ABAP Doc Casing Check\n\n"
+                f"`/check-casing` found {n} violation(s) — "
+                f"see inline comments in the **Files changed** tab.\n\n"
+                f"Fix the violations or add terms to `scripts/casing-terms.json` "
+                f"for known product names/acronyms."
+            )
+        else:
+            try:
+                output = open('/tmp/casing_output.txt').read().strip()
+                body = "## ABAP Doc Casing Check\n\nAll ABAP Doc casing checks passed. ✓"
+            except FileNotFoundError:
+                body = "## ABAP Doc Casing Check\n\nCasing check did not run — an earlier step failed."
+
+        subprocess.run(['gh', 'pr', 'comment', pr, '--body', body], check=True)
+        EOF
       env:
         GH_TOKEN: ${{ github.token }}
         GH_REPO: ${{ github.repository }}
+        PR_SHA: ${{ steps.pr.outputs.sha }}
+        PR_NUM: ${{ github.event.issue.number }}

--- a/scripts/check_abap_doc_casing.py
+++ b/scripts/check_abap_doc_casing.py
@@ -8,6 +8,8 @@ Usage:
     python check_abap_doc_casing.py                         # scan all files under file-formats/
     python check_abap_doc_casing.py file1.abap file2.abap   # scan specific files
     python check_abap_doc_casing.py --diff < changed_files  # read file list from stdin
+    python check_abap_doc_casing.py --fix                   # auto-fix all violations in-place
+    python check_abap_doc_casing.py --fix file1.abap        # auto-fix a specific file
 """
 
 import json
@@ -194,13 +196,18 @@ ANNOTATION_RE = re.compile(r'"!\s+\$')
 
 
 def check_file(filepath, preserve_set, multiword_terms):
-    """Check a single ABAP file. Returns list of (line_num, message) violations."""
+    """Check a single ABAP file.
+
+    Returns list of (line_num, message, raw_line, fixed_line) tuples.
+    raw_line / fixed_line are the full source lines (with newline) when a
+    mechanical fix is available, otherwise both are None.
+    """
     violations = []
     try:
         with open(filepath, encoding="utf-8") as f:
             lines = f.readlines()
     except (OSError, UnicodeDecodeError) as e:
-        return [(0, f"Could not read file: {e}")]
+        return [(0, f"Could not read file: {e}", None, None)]
 
     prev_was_shorttext = False
 
@@ -214,9 +221,13 @@ def check_file(filepath, preserve_set, multiword_terms):
             if title:
                 expected = expected_title_case(title, preserve_set, multiword_terms)
                 if title != expected:
-                    violations.append(
-                        (line_num, f"title not Title Case: \"{title}\" -> \"{expected}\"")
-                    )
+                    fixed = line.replace(title, expected, 1)
+                    violations.append((
+                        line_num,
+                        f"title not Title Case: \"{title}\" -> \"{expected}\"",
+                        line,
+                        fixed,
+                    ))
             prev_was_shorttext = True
             continue
 
@@ -232,15 +243,42 @@ def check_file(filepath, preserve_set, multiword_terms):
                 if desc:
                     expected = expected_sentence_case(desc, preserve_set, multiword_terms)
                     if desc != expected:
-                        violations.append(
-                            (line_num, f"description not sentence case: \"{desc}\" -> \"{expected}\"")
-                        )
+                        fixed = line.replace(desc, expected, 1)
+                        violations.append((
+                            line_num,
+                            f"description not sentence case: \"{desc}\" -> \"{expected}\"",
+                            line,
+                            fixed,
+                        ))
             prev_was_shorttext = False
             continue
 
         prev_was_shorttext = False
 
     return violations
+
+
+def fix_file(filepath, violations):
+    """Apply fixes from violations in-place. Returns number of lines changed."""
+    try:
+        with open(filepath, encoding="utf-8") as f:
+            lines = f.readlines()
+    except (OSError, UnicodeDecodeError):
+        return 0
+
+    changed = 0
+    for line_num, _msg, raw_line, fixed_line in violations:
+        if fixed_line is None or raw_line is None:
+            continue
+        idx = line_num - 1
+        if 0 <= idx < len(lines) and lines[idx] == raw_line:
+            lines[idx] = fixed_line
+            changed += 1
+
+    if changed:
+        with open(filepath, "w", encoding="utf-8") as f:
+            f.writelines(lines)
+    return changed
 
 
 def parse_pr_diff(diff_text):
@@ -299,24 +337,28 @@ def main():
     # Multi-word terms need special handling (matched as phrases, not individual words)
     multiword_terms = [t for t in preserve_terms if " " in t]
 
+    fix_mode  = "--fix"  in sys.argv
+    json_mode = "--json" in sys.argv
+    args = [a for a in sys.argv[1:] if a not in ("--fix", "--json")]
+
     # Determine files to check
     files = []
     changed_lines_filter = None  # if set, only report violations on these line numbers
 
-    if "--pr-diff" in sys.argv:
+    if "--pr-diff" in args:
         # Read unified diff from stdin, check only added/modified lines
         diff_text = sys.stdin.read()
         changed_lines_filter = parse_pr_diff(diff_text)
         files = [p for p in changed_lines_filter if p.endswith(".abap") and os.path.isfile(p)]
-    elif "--diff" in sys.argv:
+    elif "--diff" in args:
         # Read file list from stdin
         for line in sys.stdin:
             path = line.strip()
             if path.endswith(".abap") and os.path.isfile(path):
                 files.append(path)
-    elif len(sys.argv) > 1:
+    elif args:
         # Explicit file arguments
-        for arg in sys.argv[1:]:
+        for arg in args:
             if arg.startswith("-"):
                 continue
             if os.path.isfile(arg):
@@ -338,22 +380,48 @@ def main():
         sys.exit(0)
 
     total_violations = 0
+    total_fixed = 0
+    json_out = []
     for filepath in sorted(files):
         violations = check_file(filepath, preserve_set, multiword_terms)
-        for line_num, msg in violations:
-            # In --pr-diff mode, skip violations not in the PR's changed lines
-            if changed_lines_filter is not None:
-                allowed = changed_lines_filter.get(filepath, set())
-                if line_num not in allowed:
-                    continue
-            try:
-                rel = os.path.relpath(filepath)
-            except ValueError:
-                rel = filepath
-            print(f"{rel}:{line_num}: {msg}")
-            total_violations += 1
+        # Filter to changed lines in --pr-diff mode
+        if changed_lines_filter is not None:
+            allowed = changed_lines_filter.get(filepath, set())
+            violations = [v for v in violations if v[0] in allowed]
 
-    if total_violations > 0:
+        if not violations:
+            continue
+
+        try:
+            rel = os.path.relpath(filepath)
+        except ValueError:
+            rel = filepath
+
+        if fix_mode:
+            n = fix_file(filepath, violations)
+            total_fixed += n
+            for line_num, msg, raw, fixed in violations:
+                status = "fixed" if fixed is not None else "skipped"
+                print(f"{rel}:{line_num}: {status}: {msg}")
+        elif json_mode:
+            for line_num, msg, raw, fixed in violations:
+                record = {"path": rel, "line": line_num, "message": msg}
+                if fixed is not None:
+                    record["suggestion"] = fixed.rstrip("\n")
+                json_out.append(record)
+        else:
+            for line_num, msg, _, _ in violations:
+                print(f"{rel}:{line_num}: {msg}")
+        total_violations += len(violations)
+
+    if json_mode:
+        import json as _json
+        print(_json.dumps(json_out, ensure_ascii=False))
+        sys.exit(1 if total_violations > 0 else 0)
+    elif fix_mode:
+        print(f"\n{total_fixed}/{total_violations} violation(s) fixed.")
+        sys.exit(0)
+    elif total_violations > 0:
         print(f"\n{total_violations} casing violation(s) found.")
         sys.exit(1)
     else:


### PR DESCRIPTION
## Summary

Three commits fixing and improving the casing check action introduced in #755.

### 1 — Fix: `GH_REPO` missing before checkout (`fd5d9d2`)

`gh pr view` ran before `actions/checkout` with no local `.git` directory, causing:
```
fatal: not a git repository (or any of the parent directories): .git
```
Fix: add `GH_REPO: ${{ github.repository }}` to both steps that call `gh` before a repo is cloned. Also harden the summary comment step to survive a missing output file when an earlier step fails.

### 2 — Inline review comments with one-click suggestions (`3d3b230`)

The previous action posted a wall-of-text PR comment. Contributors had no way to navigate to the exact line or apply the fix.

Now each violation is posted as an **inline review comment** on the specific line in the **Files changed** tab. Where the script can compute the corrected form, a [GitHub suggestion block](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/incorporating-feedback-in-your-pull-request) is included so the contributor can apply the fix with a single click.

The summary comment is reduced to: `` `/check-casing` found N violation(s) — see inline comments in the Files changed tab. ``

### 3 — Move fix logic into the script; add `--fix` and `--json` flags (`94fed67`)

Previously the suggestion generation (read file line → replace old→new → format as suggestion block) lived only in the workflow YAML, diverging from local usage.

`check_abap_doc_casing.py` now exposes:
- `--fix` — rewrites violations in-place, useful locally:
  ```bash
  python3 scripts/check_abap_doc_casing.py --fix
  python3 scripts/check_abap_doc_casing.py --fix path/to/file.abap
  ```
- `--json` — outputs a JSON array with `path`, `line`, `message`, and `suggestion` (the corrected source line). Used by the workflow instead of reimplementing the logic inline.

The workflow is now a thin shell: run `--pr-diff --json`, parse structured output, call the GitHub API.

## Test plan
- [ ] Comment `/check-casing` on a PR with a casing violation — inline comments with suggestion blocks should appear in **Files changed**
- [ ] Click **Apply suggestion** on one of the inline comments — the fix should be committed directly
- [ ] Comment `/check-casing` on a clean PR — a single pass comment should be posted, no inline comments
- [ ] Run `python3 scripts/check_abap_doc_casing.py --fix` locally — violations should be rewritten in-place

🤖 Generated with Claude Code