### PR TITLE
Fix AFF review reminder workflow for fork PRs

### DIFF
--- a/.github/workflows/aff-review-reminder.yml
+++ b/.github/workflows/aff-review-reminder.yml
@@ -1,7 +1,7 @@
 name: AFF Review Process Reminder
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened]
     paths:
       - 'file-formats/**'


### PR DESCRIPTION
The workflow was failing on PRs from forks with "Resource not accessible by integration" error when trying to post comments. This is because pull_request triggers run with the fork's limited permissions.

Changed from pull_request to pull_request_target to run in the base repository's context with write permissions, similar to the abap-doc-casing.yml workflow.

Similar fix required as in https://github.com/SAP/abap-file-formats/pull/768