### PR TITLE
Fix Link Check Workflow

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -14,8 +14,13 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+      - name: Set up Chrome
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@v2
       - name: Run linkspector
         uses: umbrelladocs/action-linkspector@v1
+        env:
+          PUPPETEER_EXECUTABLE_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
         with:
           reporter: github-pr-review
           fail_on_error: true


### PR DESCRIPTION
# Fix Link Check Workflow

### Bug Fix

🐛 Fixed the Markdown link check CI workflow by explicitly setting up Chrome and configuring Puppeteer to use it during link checking.

### Changes

* `.github/workflows/markdown-link-check.yml`: Added a `Set up Chrome` step using `browser-actions/setup-chrome@v2` before running `linkspector`, and passed the Chrome executable path to Puppeteer via the `PUPPETEER_EXECUTABLE_PATH` environment variable. This ensures the link checker has a reliable browser available for rendering and checking links.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.22.0`

- Correlation ID: `cbd57a79-dee0-430e-aac2-7539e62a86d0`
- Event Trigger: `issue_comment.edited`
</details>
