### PR TITLE
PROG: Set program type in include example

### DIFF
--- a/file-formats/prog/examples/include/z_aff_example_include.prog.json
+++ b/file-formats/prog/examples/include/z_aff_example_include.prog.json
@@ -6,5 +6,6 @@
   },
   "generalInformation": {
     "programStatus": "customerProductionProgram"
+    "programType": "include"
   }
 }


### PR DESCRIPTION
The PROG schema defines the `programType` property to be one of
```json
"enum": [
  "executableProgram",
  "modulePool",
  "subroutinePool",
  "include"
],
```
With a default being defines as
```json
"default": "executableProgram"
```
The include example does not define a `programType` in its properties. By the default, it would then fall back to `executableProgram` which obviously makes no sense. I assume the default is set as intended and the include is simply missing the property.