### PR TITLE
Update @abaplint packages to fix transpiler regression

### DIFF
--- a/generate/package-lock.json
+++ b/generate/package-lock.json
@@ -9,26 +9,26 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@abaplint/database-sqlite": "^2.11.78",
-        "@abaplint/runtime": "^2.13.11",
-        "@abaplint/transpiler-cli": "^2.13.11",
+        "@abaplint/database-sqlite": "^2.13.40",
+        "@abaplint/runtime": "^2.13.60",
+        "@abaplint/transpiler-cli": "^2.13.60",
         "@actions/core": "^3.0.1",
         "oras-pull": "^0.1.12"
       }
     },
     "node_modules/@abaplint/database-sqlite": {
-      "version": "2.11.78",
-      "resolved": "https://registry.npmjs.org/@abaplint/database-sqlite/-/database-sqlite-2.11.78.tgz",
-      "integrity": "sha512-1s5GhhwzcupKQhK2lZW7GKIvsz/WukgjuLk2oHmlSXWGFtapLYO9wJCtUSmSNTMNuXXaVt8ks2t2RH8SVj6hCg==",
+      "version": "2.13.40",
+      "resolved": "https://registry.npmjs.org/@abaplint/database-sqlite/-/database-sqlite-2.13.40.tgz",
+      "integrity": "sha512-mgY84XJtoNThMXxNrsw9eq3Emc98lHMFlGJ9swz6nFJ5x+sivp5/lhr0SBJmFPnbg0KBj+dRb4Xgg3mKBABazQ==",
       "license": "MIT",
       "dependencies": {
         "sql.js": "^1.11.0"
       }
     },
     "node_modules/@abaplint/runtime": {
-      "version": "2.13.11",
-      "resolved": "https://registry.npmjs.org/@abaplint/runtime/-/runtime-2.13.11.tgz",
-      "integrity": "sha512-X82A2QdZUEeTlyPGSXzuCT0p5jykk6gobBILF10ZSdBGWQVNSMup8mAcRbeZJvXPvE++V+1Oamn5kaM5epU0Eg==",
+      "version": "2.13.60",
+      "resolved": "https://registry.npmjs.org/@abaplint/runtime/-/runtime-2.13.60.tgz",
+      "integrity": "sha512-sjp4al5n3geyOiudQqYHWeat+3Nz3miKPmi8+ru3fBwX7h5i89eMbZebsP/qrBi3X5x5Gd/xk4e2fRlBck2qZw==",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^0.3.2"
@@ -38,9 +38,9 @@
       }
     },
     "node_modules/@abaplint/transpiler-cli": {
-      "version": "2.13.11",
-      "resolved": "https://registry.npmjs.org/@abaplint/transpiler-cli/-/transpiler-cli-2.13.11.tgz",
-      "integrity": "sha512-4XLkBF1144CGibVmjqA/4F7gUL5eathfXleJCHJU0bNwHWgYu+H06cjrzRdOyhgTZLM0LGRlQTeOjowcLlCu6w==",
+      "version": "2.13.60",
+      "resolved": "https://registry.npmjs.org/@abaplint/transpiler-cli/-/transpiler-cli-2.13.60.tgz",
+      "integrity": "sha512-suDLfifqjNDqc0F0hR88+0TSQXX5zhvwCO0eMTQSVgsyIuNUwN1khl1nCnzdgF+NU7Te6h09C93cra1md9D1ww==",
       "license": "MIT",
       "bin": {
         "abap_transpile": "abap_transpile"

--- a/generate/package.json
+++ b/generate/package.json
@@ -22,9 +22,9 @@
   },
   "homepage": "https://github.com/SAP/abap-file-formats#readme",
   "dependencies": {
-    "@abaplint/database-sqlite": "^2.11.78",
-    "@abaplint/runtime": "^2.13.11",
-    "@abaplint/transpiler-cli": "^2.13.11",
+    "@abaplint/database-sqlite": "^2.13.40",
+    "@abaplint/runtime": "^2.13.60",
+    "@abaplint/transpiler-cli": "^2.13.60",
     "@actions/core": "^3.0.1",
     "oras-pull": "^0.1.12"
   }


### PR DESCRIPTION
## Summary

- `open-abap-core` commit [6f8def2](https://github.com/open-abap/open-abap-core/commit/6f8def2) ("authority check double #1194", Aug 19) added `cl_aunit_auth_check_types_def` — a new class containing an ABAP `ENUM` type
- `@abaplint/transpiler-cli@2.13.11` generates broken JavaScript for that `ENUM` pattern, referencing `novalueClassAttributeEnum` before it's defined
- Since the pipeline clones `open-abap-core` at HEAD during `npm run transpile`, this broke the "Compare generated against provided" check for all open PRs (including #847)

## Fix

Bump the three `@abaplint/*` packages to their current latest versions:

| Package | Before | After |
|---|---|---|
| `@abaplint/transpiler-cli` | `^2.13.11` | `^2.13.60` |
| `@abaplint/runtime` | `^2.13.11` | `^2.13.60` |
| `@abaplint/database-sqlite` | `^2.11.78` | `^2.13.40` |

## Test plan

- [x] Reproduced the `ReferenceError: novalueClassAttributeEnum is not defined` failure locally with `2.13.11`
- [x] Ran `npm test` locally with `2.13.60` — all 96 schemas generated successfully and match committed versions